### PR TITLE
Add JarReader

### DIFF
--- a/src/main/java/net/fabricmc/mappingio/MappingReader.java
+++ b/src/main/java/net/fabricmc/mappingio/MappingReader.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import net.fabricmc.mappingio.format.EnigmaReader;
+import net.fabricmc.mappingio.format.JarReader;
 import net.fabricmc.mappingio.format.MappingFormat;
 import net.fabricmc.mappingio.format.ProGuardReader;
 import net.fabricmc.mappingio.format.SrgReader;
@@ -69,6 +70,8 @@ public final class MappingReader {
 		case "MD:":
 		case "FD:":
 			return MappingFormat.SRG;
+		case "PK\u0003":
+			return MappingFormat.JAR;
 		}
 
 		String headerStr = String.valueOf(buffer, 0, pos);
@@ -141,8 +144,12 @@ public final class MappingReader {
 		}
 
 		if (format.hasSingleFile()) {
-			try (Reader reader = Files.newBufferedReader(file)) {
-				read(reader, format, visitor);
+			if (format == MappingFormat.JAR) {
+				JarReader.read(file, visitor);
+			} else {
+				try (Reader reader = Files.newBufferedReader(file)) {
+					read(reader, format, visitor);
+				}
 			}
 		} else {
 			switch (format) {

--- a/src/main/java/net/fabricmc/mappingio/MappingReader.java
+++ b/src/main/java/net/fabricmc/mappingio/MappingReader.java
@@ -70,7 +70,8 @@ public final class MappingReader {
 		case "MD:":
 		case "FD:":
 			return MappingFormat.SRG;
-		case "PK\u0003":
+		case "PK\u0003": // zip/jar
+		case "MZ\ufffd": // windows exe
 			return MappingFormat.JAR;
 		}
 

--- a/src/main/java/net/fabricmc/mappingio/format/JarReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/JarReader.java
@@ -98,6 +98,18 @@ public class JarReader {
 				if (closeFs) fs.close();
 			}
 		} else if (fileName.endsWith(".class")) {
+			Path parent = file.getParent();
+
+			while (parent != file.getRoot()) {
+				String parentDir = parent.getName(parent.getNameCount() - 1).toString();
+
+				if (parentDir.equals("META-INF") || parentDir.equals("doc-files")) {
+					return buffer;
+				}
+
+				parent = parent.getParent();
+			}
+
 			try (SeekableByteChannel channel = Files.newByteChannel(file)) {
 				if (buffer == null) buffer = ByteBuffer.allocate((int) Math.min(channel.size() + 1, 100_000_000));
 

--- a/src/main/java/net/fabricmc/mappingio/format/JarReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/JarReader.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2021 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.mappingio.format;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystemAlreadyExistsException;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Locale;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import net.fabricmc.mappingio.MappingVisitor;
+
+public class JarReader {
+	public static void read(Path path, MappingVisitor mappingVisitor) throws IOException {
+		mappingVisitor.visitNamespaces("jar", new ArrayList<String>());
+		processFile(path, null, new AnalyzingVisitor(mappingVisitor));
+	}
+
+	private static final class DirVisitor extends SimpleFileVisitor<Path> {
+		DirVisitor(AnalyzingVisitor visitor) {
+			this.visitor = visitor;
+		}
+
+		@Override
+		public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+			buffer = processFile(file, buffer, visitor);
+
+			return FileVisitResult.CONTINUE;
+		}
+
+		private final AnalyzingVisitor visitor;
+		ByteBuffer buffer;
+	}
+
+	@SuppressWarnings("resource")
+	private static ByteBuffer processFile(Path file, ByteBuffer buffer, AnalyzingVisitor visitor) throws IOException {
+		String fileName = file.getFileName().toString().toLowerCase(Locale.ENGLISH);
+
+		if (fileName.endsWith(".jar")) {
+			URI uri = file.toUri();
+
+			try {
+				uri = new URI("jar:".concat(uri.getScheme()), uri.getHost(), uri.getPath(), uri.getFragment());
+			} catch (URISyntaxException e) {
+				throw new IOException(e);
+			}
+
+			FileSystem fs = null;
+			boolean closeFs = false;
+
+			try {
+				try {
+					fs = FileSystems.newFileSystem(uri, Collections.emptyMap());
+					closeFs = true;
+				} catch (FileSystemAlreadyExistsException e) {
+					fs = FileSystems.getFileSystem(uri);
+				}
+
+				DirVisitor dirVisitor = new DirVisitor(visitor);
+
+				for (Path rootDir : fs.getRootDirectories()) {
+					Files.walkFileTree(rootDir, dirVisitor);
+				}
+
+				buffer = dirVisitor.buffer;
+			} finally {
+				if (closeFs) fs.close();
+			}
+		} else if (fileName.endsWith(".class")) {
+			try (SeekableByteChannel channel = Files.newByteChannel(file)) {
+				if (buffer == null) buffer = ByteBuffer.allocate((int) Math.min(channel.size() + 1, 100_000_000));
+
+				while (channel.read(buffer) >= 0) {
+					if (!buffer.hasRemaining()) {
+						ByteBuffer newBuffer = ByteBuffer.allocate(buffer.capacity() * 2);
+						buffer.flip();
+						newBuffer.put(buffer);
+						buffer = newBuffer;
+					}
+				}
+			}
+
+			buffer.flip();
+			processClass(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining(), visitor);
+			buffer.clear();
+		}
+
+		return buffer;
+	}
+
+	private static void processClass(byte[] classBytes, int offset, int length, AnalyzingVisitor visitor) {
+		ClassReader reader = new ClassReader(classBytes, offset, length);
+		reader.accept(visitor, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG);
+	}
+
+	private static final class AnalyzingVisitor extends ClassVisitor {
+		AnalyzingVisitor(MappingVisitor mappingVisitor) {
+			super(Integer.getInteger("mappingIo.asmApiVersion", Opcodes.ASM9));
+
+			this.mappingVisitor = mappingVisitor;
+		}
+
+		@Override
+		public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+			try {
+				mappingVisitor.visitClass(name);
+			} catch (IOException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		}
+
+		@Override
+		public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
+			try {
+				mappingVisitor.visitField(name, descriptor);
+			} catch (IOException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+
+			return null;
+		}
+
+		@Override
+		public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+			try {
+				mappingVisitor.visitMethod(name, descriptor);
+			} catch (IOException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+
+			return null;
+		}
+
+		private final MappingVisitor mappingVisitor;
+	}
+}

--- a/src/main/java/net/fabricmc/mappingio/format/JarReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/JarReader.java
@@ -19,6 +19,7 @@ package net.fabricmc.mappingio.format;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.zip.ZipEntry;
@@ -44,7 +45,7 @@ public class JarReader {
 		while (entries.hasMoreElements()) {
 			ZipEntry entry = entries.nextElement();
 			String entryName = entry.getName();
-			String parentName = Path.of(entryName).getParent().toString();
+			String parentName = Paths.get("/", entryName).getParent().toString();
 
 			if (entryName.endsWith(".class") && !parentName.contains("-")) {
 				processClass(zipFile.getInputStream(entry), analyzingVisitor);

--- a/src/main/java/net/fabricmc/mappingio/format/JarReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/JarReader.java
@@ -68,6 +68,18 @@ public class JarReader {
 		String fileName = file.getFileName().toString().toLowerCase(Locale.ENGLISH);
 
 		if (fileName.endsWith(".jar")) {
+			Path parent = file.getParent();
+
+			while (parent != file.getRoot()) {
+				String parentDir = parent.getName(parent.getNameCount() - 1).toString();
+
+				if (parentDir.equals("doc-files")) {
+					return buffer;
+				}
+
+				parent = parent.getParent();
+			}
+
 			URI uri = file.toUri();
 
 			try {

--- a/src/main/java/net/fabricmc/mappingio/format/JarReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/JarReader.java
@@ -103,7 +103,7 @@ public class JarReader {
 			while (parent != file.getRoot()) {
 				String parentDir = parent.getName(parent.getNameCount() - 1).toString();
 
-				if (parentDir.equals("META-INF") || parentDir.equals("doc-files")) {
+				if (parentDir.contains("-")) {
 					return buffer;
 				}
 

--- a/src/main/java/net/fabricmc/mappingio/format/JarReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/JarReader.java
@@ -44,8 +44,9 @@ public class JarReader {
 		while (entries.hasMoreElements()) {
 			ZipEntry entry = entries.nextElement();
 			String entryName = entry.getName();
+			String parentName = Path.of(entryName).getParent().toString();
 
-			if (entryName.endsWith(".class") && !entryName.contains("-")) {
+			if (entryName.endsWith(".class") && !parentName.contains("-")) {
 				processClass(zipFile.getInputStream(entry), analyzingVisitor);
 			}
 		}

--- a/src/main/java/net/fabricmc/mappingio/format/MappingFormat.java
+++ b/src/main/java/net/fabricmc/mappingio/format/MappingFormat.java
@@ -24,7 +24,8 @@ public enum MappingFormat {
 	SRG("SRG", "srg", false, false, false, false, false),
 	TSRG("TSRG", "tsrg", false, false, false, false, false),
 	TSRG2("TSRG2", "tsrg", true, false, false, true, false),
-	PROGUARD("ProGuard", "map", false, true, false, false, false);
+	PROGUARD("ProGuard", "map", false, true, false, false, false),
+	JAR("JAR", "jar", false, true, false, true, true);
 
 	MappingFormat(String name, String fileExt,
 			boolean hasNamespaces, boolean hasFieldDescriptors,


### PR DESCRIPTION
This PR adds support for reading an empty mapping (source only) from a jar file. The result can be written out as Enigma and Tiny v2, Tiny v1 skips everything without a destination so it can't be used.