### PR TITLE
Support method vars with same lv-index but different lv-start-offsets

### DIFF
--- a/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
@@ -1120,36 +1120,22 @@ public final class MemoryMappingTree implements MappingTree, MappingVisitor {
 
 			if (lvIndex >= 0) {
 				boolean hasMissing = false;
-				MethodVarEntry bestMatch = null;
+				MethodVarEntry foundEntry = null;
 
 				for (MethodVarEntry entry : vars) {
 					if (entry.lvIndex != lvIndex) {
 						if (entry.lvIndex < 0) hasMissing = true;
 						continue;
 					}
-
-					if (bestMatch == null) {
-						bestMatch = entry;
-					} else {
-						int startOpDeltaImprovement;
-
-						if (startOpIdx < 0 || bestMatch.startOpIdx < 0 && entry.startOpIdx < 0) {
-							startOpDeltaImprovement = 0;
-						} else if (bestMatch.startOpIdx < 0) {
-							startOpDeltaImprovement = 1;
-						} else if (entry.startOpIdx < 0) {
-							startOpDeltaImprovement = -1;
-						} else {
-							startOpDeltaImprovement = Math.abs(bestMatch.startOpIdx - startOpIdx) - Math.abs(entry.startOpIdx - startOpIdx);
-						}
-
-						if (startOpDeltaImprovement > 0 || startOpDeltaImprovement == 0 && srcName != null && srcName.equals(entry.srcName) && !srcName.equals(bestMatch.srcName)) {
-							bestMatch = entry;
-						}
+					if (entry.startOpIdx != startOpIdx) {
+						if (entry.startOpIdx < 0) hasMissing = true;
+						continue;
 					}
+					foundEntry = entry;
+					break;
 				}
 
-				if (!hasMissing || bestMatch != null) return bestMatch;
+				if (!hasMissing || foundEntry != null) return foundEntry;
 			}
 
 			if (srcName != null) {


### PR DESCRIPTION
mapping-io couldn't handle multiple method vars with the same `lv-index`, but different `lv-start-offset`s before. This is because [`getVar(...)`](https://github.com/FabricMC/mapping-io/blob/597f0722d6fa6faad6a790ae1c159eabf79e3022/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java#L1104) only used `lvIndex` as a hard requirement, and `startOpIndex` was only used for getting a "best match", so it always used the already present var instead of adding a new one.

This requires the library consumer to be more careful about the `lv-start-offset` they provide as there's no "best match" checking anymore, but IMO that's a positive change either way since the previous code could lead to unpredictable behavior.

<details>
  <summary>Example</summary>
  
Code from which mappings are getting generated:
![image](https://user-images.githubusercontent.com/48808497/173161176-2c7c9eb8-0cab-4a6d-a07e-37fde1edeb3b.png)

Output before this PR:
![image](https://user-images.githubusercontent.com/48808497/173161230-8cab2a11-137c-4a42-8b16-a214392047c2.png)

Output with this PR:
![image](https://user-images.githubusercontent.com/48808497/173161264-9fb201d2-9491-4adc-a931-bbe5e5e07e10.png)


</details>