### PR TITLE
Add `VisitableMappingTree` interface

### DIFF
--- a/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
@@ -35,7 +35,7 @@ import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingFlag;
 import net.fabricmc.mappingio.MappingVisitor;
 
-public final class MemoryMappingTree implements MappingTree, MappingVisitor {
+public final class MemoryMappingTree implements VisitableMappingTree {
 	public MemoryMappingTree() {
 		this(false);
 	}
@@ -251,7 +251,7 @@ public final class MemoryMappingTree implements MappingTree, MappingVisitor {
 	@Override
 	public ClassMapping getClass(String name, int namespace) {
 		if (namespace < 0 || !indexByDstNames) {
-			return MappingTree.super.getClass(name, namespace);
+			return VisitableMappingTree.super.getClass(name, namespace);
 		} else {
 			return classesByDstNames[namespace].get(name);
 		}

--- a/src/main/java/net/fabricmc/mappingio/tree/VisitableMappingTree.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/VisitableMappingTree.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.mappingio.tree;
+
+import net.fabricmc.mappingio.MappingVisitor;
+
+public interface VisitableMappingTree extends MappingTree, MappingVisitor {
+}


### PR DESCRIPTION
This allows greater flexibility, as consumers no longer have to rely on a specific MappingTree implementation directly (`MemoryMappingTree`).