### PR TITLE
Prevent instantiation of mapping readers and util classes

### DIFF
--- a/src/main/java/net/fabricmc/mappingio/MappingReader.java
+++ b/src/main/java/net/fabricmc/mappingio/MappingReader.java
@@ -36,6 +36,9 @@ import net.fabricmc.mappingio.format.tiny.Tiny2FileReader;
 import net.fabricmc.mappingio.format.tsrg.TsrgFileReader;
 
 public final class MappingReader {
+	private MappingReader() {
+	}
+
 	public static MappingFormat detectFormat(Path file) throws IOException {
 		if (Files.isDirectory(file)) {
 			return MappingFormat.ENIGMA_DIR;

--- a/src/main/java/net/fabricmc/mappingio/MappingUtil.java
+++ b/src/main/java/net/fabricmc/mappingio/MappingUtil.java
@@ -19,6 +19,9 @@ package net.fabricmc.mappingio;
 import java.util.Map;
 
 public final class MappingUtil {
+	private MappingUtil() {
+	}
+
 	public static String mapDesc(String desc, Map<String, String> clsMap) {
 		return mapDesc(desc, 0, desc.length(), clsMap);
 	}

--- a/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaDirReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaDirReader.java
@@ -27,6 +27,9 @@ import net.fabricmc.mappingio.MappingUtil;
 import net.fabricmc.mappingio.MappingVisitor;
 
 public final class EnigmaDirReader {
+	private EnigmaDirReader() {
+	}
+
 	public static void read(Path dir, MappingVisitor visitor) throws IOException {
 		read(dir, MappingUtil.NS_SOURCE_FALLBACK, MappingUtil.NS_TARGET_FALLBACK, visitor);
 	}

--- a/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaFileReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaFileReader.java
@@ -30,6 +30,9 @@ import net.fabricmc.mappingio.tree.MappingTree;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
 public final class EnigmaFileReader {
+	private EnigmaFileReader() {
+	}
+
 	public static void read(Reader reader, MappingVisitor visitor) throws IOException {
 		read(reader, MappingUtil.NS_SOURCE_FALLBACK, MappingUtil.NS_TARGET_FALLBACK, visitor);
 	}

--- a/src/main/java/net/fabricmc/mappingio/format/proguard/ProGuardFileReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/proguard/ProGuardFileReader.java
@@ -29,6 +29,9 @@ import net.fabricmc.mappingio.MappingUtil;
 import net.fabricmc.mappingio.MappingVisitor;
 
 public final class ProGuardFileReader {
+	private ProGuardFileReader() {
+	}
+
 	public static void read(Reader reader, MappingVisitor visitor) throws IOException {
 		read(reader, MappingUtil.NS_SOURCE_FALLBACK, MappingUtil.NS_TARGET_FALLBACK, visitor);
 	}

--- a/src/main/java/net/fabricmc/mappingio/format/srg/SrgFileReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/srg/SrgFileReader.java
@@ -30,6 +30,9 @@ import net.fabricmc.mappingio.tree.MappingTree;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
 public final class SrgFileReader {
+	private SrgFileReader() {
+	}
+
 	public static void read(Reader reader, MappingVisitor visitor) throws IOException {
 		read(reader, MappingUtil.NS_SOURCE_FALLBACK, MappingUtil.NS_TARGET_FALLBACK, visitor);
 	}

--- a/src/main/java/net/fabricmc/mappingio/format/tiny/Tiny1FileReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/tiny/Tiny1FileReader.java
@@ -30,6 +30,9 @@ import net.fabricmc.mappingio.tree.MappingTree;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
 public final class Tiny1FileReader {
+	private Tiny1FileReader() {
+	}
+
 	public static List<String> getNamespaces(Reader reader) throws IOException {
 		return getNamespaces(new ColumnFileReader(reader, '\t'));
 	}

--- a/src/main/java/net/fabricmc/mappingio/format/tiny/Tiny2FileReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/tiny/Tiny2FileReader.java
@@ -27,6 +27,9 @@ import net.fabricmc.mappingio.MappingVisitor;
 import net.fabricmc.mappingio.format.ColumnFileReader;
 
 public final class Tiny2FileReader {
+	private Tiny2FileReader() {
+	}
+
 	public static List<String> getNamespaces(Reader reader) throws IOException {
 		return getNamespaces(new ColumnFileReader(reader, '\t'));
 	}

--- a/src/main/java/net/fabricmc/mappingio/format/tiny/Tiny2Util.java
+++ b/src/main/java/net/fabricmc/mappingio/format/tiny/Tiny2Util.java
@@ -23,6 +23,9 @@ import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
 public final class Tiny2Util {
+	private Tiny2Util() {
+	}
+
 	public static boolean needEscape(String s) {
 		for (int pos = 0, len = s.length(); pos < len; pos++) {
 			char c = s.charAt(pos);

--- a/src/main/java/net/fabricmc/mappingio/format/tsrg/TsrgFileReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/tsrg/TsrgFileReader.java
@@ -30,6 +30,9 @@ import net.fabricmc.mappingio.MappingVisitor;
 import net.fabricmc.mappingio.format.ColumnFileReader;
 
 public final class TsrgFileReader {
+	private TsrgFileReader() {
+	}
+
 	public static List<String> getNamespaces(Reader reader) throws IOException {
 		return getNamespaces(new ColumnFileReader(reader, ' '));
 	}

--- a/src/main/java/net/fabricmc/mappingio/tree/ClassAnalysisDescCompleter.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/ClassAnalysisDescCompleter.java
@@ -43,6 +43,9 @@ import net.fabricmc.mappingio.tree.MappingTree.FieldMapping;
 import net.fabricmc.mappingio.tree.MappingTree.MethodMapping;
 
 public final class ClassAnalysisDescCompleter {
+	private ClassAnalysisDescCompleter() {
+	}
+
 	public static void process(Path path, String namespace, MappingTree mappingTree) throws IOException {
 		AnalyzingVisitor visitor = new AnalyzingVisitor(namespace, mappingTree);
 


### PR DESCRIPTION
They are intended for static use only, and making them non-instantiable better conveys that to the user.