### PR TITLE
Automatically flush all writers in `visitEnd`

### DIFF
--- a/src/main/java/net/fabricmc/mappingio/MappingWriter.java
+++ b/src/main/java/net/fabricmc/mappingio/MappingWriter.java
@@ -52,4 +52,10 @@ public interface MappingWriter extends Closeable, MappingVisitor {
 		default: throw new UnsupportedOperationException("format "+format+" is not implemented");
 		}
 	}
+
+	@Override
+	default boolean visitEnd() throws IOException {
+		close();
+		return true;
+	}
 }

--- a/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaWriterBase.java
+++ b/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaWriterBase.java
@@ -87,13 +87,6 @@ abstract class EnigmaWriterBase implements MappingWriter {
 	}
 
 	@Override
-	public boolean visitEnd() throws IOException {
-		close();
-
-		return true;
-	}
-
-	@Override
 	public void visitDstName(MappedElementKind targetKind, int namespace, String name) throws IOException {
 		if (namespace != 0) return;
 


### PR DESCRIPTION
Closes #12.