### PR TITLE
Allow null parameter destination names in Enigma format

### DIFF
--- a/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaFileReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaFileReader.java
@@ -193,8 +193,7 @@ public final class EnigmaFileReader {
 
 					if (visitor.visitMethodArg(-1, lvIndex, null)) {
 						String dstName = reader.nextCol();
-						if (dstName == null) throw new IOException("missing var-name-b column in line "+reader.getLineNumber());
-						if (!dstName.isEmpty()) visitor.visitDstName(MappedElementKind.METHOD_ARG, 0, dstName);
+						if (dstName != null && !dstName.isEmpty()) visitor.visitDstName(MappedElementKind.METHOD_ARG, 0, dstName);
 
 						readElement(reader, MappedElementKind.METHOD_ARG, indent, commentSb, visitor);
 					}


### PR DESCRIPTION
This is consistent with all other elements (classes, fields and methods). It doesn't break compatibility, since Enigma itself doesn't handle empty parameter destination names correctly and produces invalid files.