### PR TITLE
Add Javadocs to mapping formats

### DIFF
--- a/src/main/java/net/fabricmc/mappingio/MappingReader.java
+++ b/src/main/java/net/fabricmc/mappingio/MappingReader.java
@@ -157,8 +157,6 @@ public final class MappingReader {
 			case ENIGMA_DIR:
 				EnigmaDirReader.read(file, visitor);
 				break;
-			case MCP_DIR:
-				throw new UnsupportedOperationException(); // TODO: implement
 			default:
 				throw new IllegalStateException();
 			}

--- a/src/main/java/net/fabricmc/mappingio/format/MappingFormat.java
+++ b/src/main/java/net/fabricmc/mappingio/format/MappingFormat.java
@@ -133,8 +133,7 @@ public enum MappingFormat {
 	/**
 	 * ProGuard's mapping format, as specified <a href="https://www.guardsquare.com/manual/tools/retrace">here</a>.
 	 */
-	PROGUARD_FILE("ProGuard file", "map", false, true, false, false, false),
-	MCP_DIR("MCP directory", null, false, false, true, true, false);
+	PROGUARD_FILE("ProGuard file", "map", false, true, false, false, false);
 
 	MappingFormat(String name, String fileExt,
 			boolean hasNamespaces, boolean hasFieldDescriptors,

--- a/src/main/java/net/fabricmc/mappingio/format/MappingFormat.java
+++ b/src/main/java/net/fabricmc/mappingio/format/MappingFormat.java
@@ -16,16 +16,125 @@
 
 package net.fabricmc.mappingio.format;
 
+/**
+ * Represents a supported mapping format. Feature comparison table:
+ * <table>
+ *   <tr>
+ *     <th>Format</th>
+ *     <th>Namespaces</th>
+ *     <th>Field descriptors</th>
+ *     <th>Comments</th>
+ *     <th>Parameters</th>
+ *     <th>Local variables</th>
+ *     <th>Metadata</th>
+ *   </tr>
+ *   <tr>
+ *     <td>Tiny v1</td>
+ *     <td>✔</td>
+ *     <td>✔</td>
+ *     <td>✖</td>
+ *     <td>✖</td>
+ *     <td>✖</td>
+ *     <td>✔ (Currently limited support)</td>
+ *   </tr>
+ *   <tr>
+ *     <td>Tiny v2</td>
+ *     <td>✔</td>
+ *     <td>✔</td>
+ *     <td>✔</td>
+ *     <td>✔</td>
+ *     <td>✔</td>
+ *     <td>✔</td>
+ *   </tr>
+ *   <tr>
+ *     <td>Enigma</td>
+ *     <td>✖</td>
+ *     <td>✔</td>
+ *     <td>✔</td>
+ *     <td>✔</td>
+ *     <td>✖</td>
+ *     <td>✖</td>
+ *   </tr>
+ *   <tr>
+ *     <td>SRG</td>
+ *     <td>✖</td>
+ *     <td>✖</td>
+ *     <td>✖</td>
+ *     <td>✖</td>
+ *     <td>✖</td>
+ *     <td>✖</td>
+ *   </tr>
+ *   <tr>
+ *     <td>TSRG</td>
+ *     <td>✖</td>
+ *     <td>✖</td>
+ *     <td>✖</td>
+ *     <td>✖</td>
+ *     <td>✖</td>
+ *     <td>✖</td>
+ *   </tr>
+ *   <tr>
+ *     <td>TSRG2</td>
+ *     <td>✔</td>
+ *     <td>✖</td>
+ *     <td>✖</td>
+ *     <td>✔</td>
+ *     <td>✖</td>
+ *     <td>✖</td>
+ *   </tr>
+ *   <tr>
+ *     <td>ProGuard</td>
+ *     <td>✖</td>
+ *     <td>✔</td>
+ *     <td>✖</td>
+ *     <td>✖</td>
+ *     <td>✖</td>
+ *     <td>✖</td>
+ *   </tr>
+ * </table>
+ */
+// Format order is determined by importance to Fabric tooling, format family and release order therein.
 public enum MappingFormat {
+	/**
+	 * The {@code Tiny} mapping format, as specified <a href="https://fabricmc.net/wiki/documentation:tiny">here</a>.
+	 */
 	TINY_FILE("Tiny file", "tiny", true, true, false, false, false),
+
+	/**
+	 * The {@code Tiny v2} mapping format, as specified <a href="https://fabricmc.net/wiki/documentation:tiny2">here</a>.
+	 */
 	TINY_2_FILE("Tiny v2 file", "tiny", true, true, true, true, true),
+
+	/**
+	 * Enigma's mapping format, as specified <a href="https://fabricmc.net/wiki/documentation:enigma_mappings">here</a>.
+	 */
 	ENIGMA_FILE("Enigma file", "mappings", false, true, true, true, false),
+
+	/**
+	 * Enigma's mapping format (in directory form), as specified <a href="https://fabricmc.net/wiki/documentation:enigma_mappings">here</a>.
+	 */
 	ENIGMA_DIR("Enigma directory", null, false, true, true, true, false),
-	MCP_DIR("MCP directory", null, false, false, true, true, false),
+
+	/**
+	 * The {@code SRG} ({@code Searge RetroGuard}) mapping format, as specified <a href="https://github.com/MinecraftForge/SrgUtils/blob/67f30647ece29f18256ca89a23cda6216d6bd21e/src/main/java/net/minecraftforge/srgutils/InternalUtils.java#L69-L81">here</a>.
+	 */
 	SRG_FILE("SRG file", "srg", false, false, false, false, false),
+
+	/**
+	 * The {@code TSRG} ({@code Tiny SRG}, since it saves disk space over SRG) mapping format, as specified <a href="https://github.com/MinecraftForge/SrgUtils/blob/67f30647ece29f18256ca89a23cda6216d6bd21e/src/main/java/net/minecraftforge/srgutils/InternalUtils.java#L196-L213">here</a>.
+	 */
 	TSRG_FILE("TSRG file", "tsrg", false, false, false, false, false),
+
+	/**
+	 * The {@code TSRG v2} mapping format, as specified <a href="https://github.com/MinecraftForge/SrgUtils/blob/67f30647ece29f18256ca89a23cda6216d6bd21e/src/main/java/net/minecraftforge/srgutils/InternalUtils.java#L262-L285">here</a>.
+	 */
 	TSRG_2_FILE("TSRG2 file", "tsrg", true, false, false, true, false),
-	PROGUARD_FILE("ProGuard file", "map", false, true, false, false, false);
+
+	/**
+	 * ProGuard's mapping format, as specified <a href="https://www.guardsquare.com/manual/tools/retrace">here</a>.
+	 */
+	PROGUARD_FILE("ProGuard file", "map", false, true, false, false, false),
+	MCP_DIR("MCP directory", null, false, false, true, true, false);
 
 	MappingFormat(String name, String fileExt,
 			boolean hasNamespaces, boolean hasFieldDescriptors,


### PR DESCRIPTION
Provides a link to each format's specification, and adds a basic feature comparison table. Also removes the `MCP_DIR` format, since it's not actually implemented (to prevent crashes and confusion).