### PR TITLE
Add `@Nullable` annotation where applicable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,10 +38,11 @@ repositories {
 
 dependencies {
 	implementation "org.ow2.asm:asm:${project.asm_version}"
-	compileOnly "org.jetbrains:annotations:${project.jetbrains_annotations_version}"
 	implementation "net.fabricmc:tiny-remapper:${tiny_remapper_version}"
+	compileOnly "org.jetbrains:annotations:${project.jetbrains_annotations_version}"
 
 	testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
+	testCompileOnly "org.jetbrains:annotations:${project.jetbrains_annotations_version}"
 	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_jupiter_version}"
 }
 

--- a/src/main/java/net/fabricmc/mappingio/FlatMappingVisitor.java
+++ b/src/main/java/net/fabricmc/mappingio/FlatMappingVisitor.java
@@ -20,7 +20,10 @@ import static net.fabricmc.mappingio.MappingUtil.toArray;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+
+import org.jetbrains.annotations.Nullable;
 
 import net.fabricmc.mappingio.adapter.FlatAsRegularMappingVisitor;
 import net.fabricmc.mappingio.adapter.RegularAsFlatMappingVisitor;
@@ -45,7 +48,7 @@ public interface FlatMappingVisitor {
 
 	void visitNamespaces(String srcNamespace, List<String> dstNamespaces) throws IOException;
 
-	default void visitMetadata(String key, String value) throws IOException { }
+	default void visitMetadata(String key, @Nullable String value) throws IOException { }
 
 	/**
 	 * Determine whether the mapping content (classes and anything below, metadata if not part of the header) should be visited.
@@ -56,35 +59,39 @@ public interface FlatMappingVisitor {
 		return true;
 	}
 
-	boolean visitClass(String srcName, String[] dstNames) throws IOException;
-	void visitClassComment(String srcName, String[] dstNames, String comment) throws IOException;
+	boolean visitClass(String srcName, @Nullable String[] dstNames) throws IOException;
+	void visitClassComment(String srcName, @Nullable String[] dstNames, String comment) throws IOException;
 
-	boolean visitField(String srcClsName, String srcName, String srcDesc,
-			String[] dstClsNames, String[] dstNames, String[] dstDescs) throws IOException;
-	void visitFieldComment(String srcClsName, String srcName, String srcDesc,
-			String[] dstClsNames, String[] dstNames, String[] dstDescs,
+	boolean visitField(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String[] dstClsNames, @Nullable String[] dstNames, @Nullable String[] dstDescs) throws IOException;
+	void visitFieldComment(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String[] dstClsNames, @Nullable String[] dstNames, @Nullable String[] dstDescs,
 			String comment) throws IOException;
 
-	boolean visitMethod(String srcClsName, String srcName, String srcDesc,
-			String[] dstClsNames, String[] dstNames, String[] dstDescs) throws IOException;
-	void visitMethodComment(String srcClsName, String srcName, String srcDesc,
-			String[] dstClsNames, String[] dstNames, String[] dstDescs,
+	boolean visitMethod(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String[] dstClsNames, @Nullable String[] dstNames, @Nullable String[] dstDescs) throws IOException;
+	void visitMethodComment(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String[] dstClsNames, @Nullable String[] dstNames, @Nullable String[] dstDescs,
 			String comment) throws IOException;
 
-	boolean visitMethodArg(String srcClsName, String srcMethodName, String srcMethodDesc,
-			int argPosition, int lvIndex, String srcArgName,
-			String[] dstClsNames, String[] dstMethodNames, String[] dstMethodDescs, String[] dstArgNames) throws IOException;
-	void visitMethodArgComment(String srcClsName, String srcMethodName, String srcMethodDesc,
-			int argPosition, int lvIndex, String srcArgName,
-			String[] dstClsNames, String[] dstMethodNames, String[] dstMethodDescs, String[] dstArgNames,
+	boolean visitMethodArg(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int argPosition, int lvIndex, @Nullable String srcName,
+			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames,
+			@Nullable String[] dstMethodDescs, String[] dstNames) throws IOException;
+	void visitMethodArgComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int argPosition, int lvIndex, @Nullable String srcName,
+			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames,
+			@Nullable String[] dstMethodDescs, @Nullable String[] dstNames,
 			String comment) throws IOException;
 
-	boolean visitMethodVar(String srcClsName, String srcMethodName, String srcMethodDesc,
-			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcVarName,
-			String[] dstClsNames, String[] dstMethodNames, String[] dstMethodDescs, String[] dstVarNames) throws IOException;
-	void visitMethodVarComment(String srcClsName, String srcMethodName, String srcMethodDesc,
-			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcVarName,
-			String[] dstClsNames, String[] dstMethodNames, String[] dstMethodDescs, String[] dstVarNames,
+	boolean visitMethodVar(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName,
+			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames,
+			@Nullable String[] dstMethodDescs, String[] dstNames) throws IOException;
+	void visitMethodVarComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName,
+			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames,
+			@Nullable String[] dstMethodDescs, @Nullable String[] dstNames,
 			String comment) throws IOException;
 
 	/**
@@ -107,30 +114,34 @@ public interface FlatMappingVisitor {
 
 	// convenience visit methods without extra dst context
 
-	default boolean visitField(String srcClsName, String srcName, String srcDesc, String[] dstNames) throws IOException {
+	default boolean visitField(String srcClsName, String srcName, @Nullable String srcDesc, String[] dstNames) throws IOException {
+		Objects.requireNonNull(dstNames);
 		return visitField(srcClsName, srcName, srcDesc, null, dstNames, null);
 	}
 
-	default boolean visitMethod(String srcClsName, String srcName, String srcDesc, String[] dstNames) throws IOException {
+	default boolean visitMethod(String srcClsName, String srcName, @Nullable String srcDesc, String[] dstNames) throws IOException {
+		Objects.requireNonNull(dstNames);
 		return visitMethod(srcClsName, srcName, srcDesc, null, dstNames, null);
 	}
 
-	default boolean visitMethodArg(String srcClsName, String srcMethodName, String srcMethodDesc,
-			int argPosition, int lvIndex, String srcArgName,
-			String[] dstArgNames) throws IOException {
+	default boolean visitMethodArg(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int argPosition, int lvIndex, @Nullable String srcName,
+			String[] dstNames) throws IOException {
+		Objects.requireNonNull(dstNames);
 		return visitMethodArg(srcClsName, srcMethodName, srcMethodDesc,
-				argPosition, lvIndex, srcArgName,
+				argPosition, lvIndex, srcName,
 				null, null, null,
-				dstArgNames);
+				dstNames);
 	}
 
-	default boolean visitMethodVar(String srcClsName, String srcMethodName, String srcMethodDesc,
-			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcVarName,
-			String[] dstVarNames) throws IOException {
+	default boolean visitMethodVar(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName,
+			String[] dstNames) throws IOException {
+		Objects.requireNonNull(dstNames);
 		return visitMethodVar(srcClsName, srcMethodName, srcMethodDesc,
-				lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcVarName,
+				lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcName,
 				null, null, null,
-				dstVarNames);
+				dstNames);
 	}
 
 	// convenience / potentially higher efficiency visit methods for only one dst name
@@ -143,130 +154,131 @@ public interface FlatMappingVisitor {
 		visitClassComment(srcName, (String) null, comment);
 	}
 
-	default void visitClassComment(String srcName, String dstName, String comment) throws IOException {
+	default void visitClassComment(String srcName, @Nullable String dstName, String comment) throws IOException {
 		visitClassComment(srcName, toArray(dstName), comment);
 	}
 
-	default boolean visitField(String srcClsName, String srcName, String srcDesc,
+	default boolean visitField(String srcClsName, String srcName, @Nullable String srcDesc,
 			String dstName) throws IOException {
 		return visitField(srcClsName, srcName, srcDesc,
 				null, dstName, null);
 	}
 
-	default boolean visitField(String srcClsName, String srcName, String srcDesc,
-			String dstClsName, String dstName, String dstDesc) throws IOException {
+	default boolean visitField(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String dstClsName, String dstName, @Nullable String dstDesc) throws IOException {
 		return visitField(srcClsName, srcName, srcDesc,
 				toArray(dstClsName), toArray(dstName), toArray(dstDesc));
 	}
 
-	default void visitFieldComment(String srcClsName, String srcName, String srcDesc,
+	default void visitFieldComment(String srcClsName, String srcName, @Nullable String srcDesc,
 			String comment) throws IOException {
 		visitFieldComment(srcClsName, srcName, srcDesc,
 				(String) null, null, null,
 				comment);
 	}
 
-	default void visitFieldComment(String srcClsName, String srcName, String srcDesc,
-			String dstClsName, String dstName, String dstDesc,
+	default void visitFieldComment(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String dstClsName, @Nullable String dstName, @Nullable String dstDesc,
 			String comment) throws IOException {
 		visitFieldComment(srcClsName, srcName, srcDesc,
 				toArray(dstClsName), toArray(dstName), toArray(dstDesc),
 				comment);
 	}
 
-	default boolean visitMethod(String srcClsName, String srcName, String srcDesc,
+	default boolean visitMethod(String srcClsName, String srcName, @Nullable String srcDesc,
 			String dstName) throws IOException {
 		return visitMethod(srcClsName, srcName, srcDesc,
 				null, dstName, null);
 	}
 
-	default boolean visitMethod(String srcClsName, String srcName, String srcDesc,
-			String dstClsName, String dstName, String dstDesc) throws IOException {
+	default boolean visitMethod(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String dstClsName, String dstName, @Nullable String dstDesc) throws IOException {
 		return visitMethod(srcClsName, srcName, srcDesc,
 				toArray(dstClsName), toArray(dstName), toArray(dstDesc));
 	}
 
-	default void visitMethodComment(String srcClsName, String srcName, String srcDesc,
+	default void visitMethodComment(String srcClsName, String srcName, @Nullable String srcDesc,
 			String comment) throws IOException {
 		visitMethodComment(srcClsName, srcName, srcDesc,
 				(String) null, null, null,
 				comment);
 	}
 
-	default void visitMethodComment(String srcClsName, String srcName, String srcDesc,
-			String dstClsName, String dstName, String dstDesc,
+	default void visitMethodComment(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String dstClsName, @Nullable String dstName, @Nullable String dstDesc,
 			String comment) throws IOException {
 		visitMethodComment(srcClsName, srcName, srcDesc,
 				toArray(dstClsName), toArray(dstName), toArray(dstDesc),
 				comment);
 	}
 
-	default boolean visitMethodArg(String srcClsName, String srcMethodName, String srcMethodDesc,
-			int argPosition, int lvIndex, String srcArgName,
-			String dstArgName) throws IOException {
+	default boolean visitMethodArg(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int argPosition, int lvIndex, @Nullable String srcName, String dstName) throws IOException {
 		return visitMethodArg(srcClsName, srcMethodName, srcMethodDesc,
-				argPosition, lvIndex, srcArgName,
-				null, null, null, dstArgName);
+				argPosition, lvIndex, srcName,
+				null, null, null, dstName);
 	}
 
-	default boolean visitMethodArg(String srcClsName, String srcMethodName, String srcMethodDesc,
-			int argPosition, int lvIndex, String srcArgName,
-			String dstClsName, String dstMethodName, String dstMethodDesc, String dstArgName) throws IOException {
+	default boolean visitMethodArg(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int argPosition, int lvIndex, @Nullable String srcName,
+			@Nullable String dstClsName, @Nullable String dstMethodName,
+			@Nullable String dstMethodDesc, String dstName) throws IOException {
 		return visitMethodArg(srcClsName, srcMethodName, srcMethodDesc,
-				argPosition, lvIndex, srcArgName,
-				toArray(dstClsName), toArray(dstMethodName), toArray(dstMethodDesc), toArray(dstArgName));
+				argPosition, lvIndex, srcName,
+				toArray(dstClsName), toArray(dstMethodName), toArray(dstMethodDesc), toArray(dstName));
 	}
 
-	default void visitMethodArgComment(String srcClsName, String srcMethodName, String srcMethodDesc,
-			int argPosition, int lvIndex, String srcArgName,
-			String comment) throws IOException {
+	default void visitMethodArgComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int argPosition, int lvIndex, @Nullable String srcName, String comment) throws IOException {
 		visitMethodArgComment(srcClsName, srcMethodName, srcMethodDesc,
-				argPosition, lvIndex, srcArgName,
+				argPosition, lvIndex, srcName,
 				(String) null, null, null, null,
 				comment);
 	}
 
-	default void visitMethodArgComment(String srcClsName, String srcMethodName, String srcMethodDesc,
-			int argPosition, int lvIndex, String srcArgName,
-			String dstClsName, String dstMethodName, String dstMethodDesc, String dstArgName,
+	default void visitMethodArgComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int argPosition, int lvIndex, @Nullable String srcName,
+			@Nullable String dstClsName, @Nullable String dstMethodName,
+			@Nullable String dstMethodDesc, @Nullable String dstName,
 			String comment) throws IOException {
-		visitMethodArgComment(srcClsName, srcMethodName, srcMethodDesc, argPosition, lvIndex, srcArgName,
-				toArray(dstClsName), toArray(dstMethodName), toArray(dstMethodDesc), toArray(dstArgName),
+		visitMethodArgComment(srcClsName, srcMethodName, srcMethodDesc, argPosition, lvIndex, srcName,
+				toArray(dstClsName), toArray(dstMethodName), toArray(dstMethodDesc), toArray(dstName),
 				comment);
 	}
 
-	default boolean visitMethodVar(String srcClsName, String srcMethodName, String srcMethodDesc,
-			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcVarName,
-			String dstVarName) throws IOException {
+	default boolean visitMethodVar(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName,
+			String dstName) throws IOException {
 		return visitMethodVar(srcClsName, srcMethodName, srcMethodDesc,
-				lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcVarName,
-				null, null, null, dstVarName);
+				lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcName,
+				null, null, null, dstName);
 	}
 
-	default boolean visitMethodVar(String srcClsName, String srcMethodName, String srcMethodDesc,
-			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcVarName,
-			String dstClsName, String dstMethodName, String dstMethodDesc, String dstVarName) throws IOException {
+	default boolean visitMethodVar(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName,
+			@Nullable String dstClsName, @Nullable String dstMethodName, @Nullable String dstMethodDesc,
+			String dstName) throws IOException {
 		return visitMethodVar(srcClsName, srcMethodName, srcMethodDesc,
-				lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcVarName,
-				toArray(dstClsName), toArray(dstMethodName), toArray(dstMethodDesc), toArray(dstVarName));
+				lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcName,
+				toArray(dstClsName), toArray(dstMethodName), toArray(dstMethodDesc), toArray(dstName));
 	}
 
-	default void visitMethodVarComment(String srcClsName, String srcMethodName, String srcMethodDesc,
-			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcVarName,
+	default void visitMethodVarComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName,
 			String comment) throws IOException {
 		visitMethodVarComment(srcClsName, srcMethodName, srcMethodDesc,
-				lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcVarName,
+				lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcName,
 				(String) null, null, null, null,
 				comment);
 	}
 
-	default void visitMethodVarComment(String srcClsName, String srcMethodName, String srcMethodDesc,
-			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcVarName,
-			String dstClsName, String dstMethodName, String dstMethodDesc, String dstVarName,
-			String comment) throws IOException {
+	default void visitMethodVarComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName,
+			@Nullable String dstClsName, @Nullable String dstMethodName, @Nullable String dstMethodDesc,
+			@Nullable String dstName, String comment) throws IOException {
 		visitMethodVarComment(srcClsName, srcMethodName, srcMethodDesc,
-				lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcVarName,
-				toArray(dstClsName), toArray(dstMethodName), toArray(dstMethodDesc), toArray(dstVarName),
+				lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcName,
+				toArray(dstClsName), toArray(dstMethodName), toArray(dstMethodDesc), toArray(dstName),
 				comment);
 	}
 }

--- a/src/main/java/net/fabricmc/mappingio/MappingReader.java
+++ b/src/main/java/net/fabricmc/mappingio/MappingReader.java
@@ -26,6 +26,8 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.fabricmc.mappingio.format.MappingFormat;
 import net.fabricmc.mappingio.format.enigma.EnigmaDirReader;
 import net.fabricmc.mappingio.format.enigma.EnigmaFileReader;
@@ -39,6 +41,7 @@ public final class MappingReader {
 	private MappingReader() {
 	}
 
+	@Nullable
 	public static MappingFormat detectFormat(Path file) throws IOException {
 		if (Files.isDirectory(file)) {
 			return MappingFormat.ENIGMA_DIR;
@@ -49,6 +52,7 @@ public final class MappingReader {
 		}
 	}
 
+	@Nullable
 	public static MappingFormat detectFormat(Reader reader) throws IOException {
 		char[] buffer = new char[DETECT_HEADER_LEN];
 		int pos = 0;

--- a/src/main/java/net/fabricmc/mappingio/MappingVisitor.java
+++ b/src/main/java/net/fabricmc/mappingio/MappingVisitor.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
+import org.jetbrains.annotations.Nullable;
+
 /**
  * Visitor with order implied context and consecutive dst name visits.
  *
@@ -69,7 +71,7 @@ public interface MappingVisitor {
 
 	void visitNamespaces(String srcNamespace, List<String> dstNamespaces) throws IOException;
 
-	default void visitMetadata(String key, String value) throws IOException { }
+	default void visitMetadata(String key, @Nullable String value) throws IOException { }
 
 	/**
 	 * Determine whether the mapping content (classes and anything below, metadata if not part of the header) should be visited.
@@ -81,10 +83,10 @@ public interface MappingVisitor {
 	}
 
 	boolean visitClass(String srcName) throws IOException;
-	boolean visitField(String srcName, String srcDesc) throws IOException;
-	boolean visitMethod(String srcName, String srcDesc) throws IOException;
-	boolean visitMethodArg(int argPosition, int lvIndex, String srcName) throws IOException;
-	boolean visitMethodVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcName) throws IOException;
+	boolean visitField(String srcName, @Nullable String srcDesc) throws IOException;
+	boolean visitMethod(String srcName, @Nullable String srcDesc) throws IOException;
+	boolean visitMethodArg(int argPosition, int lvIndex, @Nullable String srcName) throws IOException;
+	boolean visitMethodVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName) throws IOException;
 
 	/**
 	 * Finish the visitation pass.

--- a/src/main/java/net/fabricmc/mappingio/adapter/FlatAsRegularMappingVisitor.java
+++ b/src/main/java/net/fabricmc/mappingio/adapter/FlatAsRegularMappingVisitor.java
@@ -21,6 +21,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.fabricmc.mappingio.FlatMappingVisitor;
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingFlag;
@@ -65,7 +67,7 @@ public final class FlatAsRegularMappingVisitor implements MappingVisitor {
 	}
 
 	@Override
-	public void visitMetadata(String key, String value) throws IOException {
+	public void visitMetadata(String key, @Nullable String value) throws IOException {
 		next.visitMetadata(key, value);
 	}
 
@@ -85,7 +87,7 @@ public final class FlatAsRegularMappingVisitor implements MappingVisitor {
 	}
 
 	@Override
-	public boolean visitField(String srcName, String srcDesc) {
+	public boolean visitField(String srcName, @Nullable String srcDesc) {
 		this.srcMemberName = srcName;
 		this.srcMemberDesc = srcDesc;
 
@@ -97,7 +99,7 @@ public final class FlatAsRegularMappingVisitor implements MappingVisitor {
 	}
 
 	@Override
-	public boolean visitMethod(String srcName, String srcDesc) {
+	public boolean visitMethod(String srcName, @Nullable String srcDesc) {
 		this.srcMemberName = srcName;
 		this.srcMemberDesc = srcDesc;
 
@@ -109,7 +111,7 @@ public final class FlatAsRegularMappingVisitor implements MappingVisitor {
 	}
 
 	@Override
-	public boolean visitMethodArg(int argPosition, int lvIndex, String srcName) {
+	public boolean visitMethodArg(int argPosition, int lvIndex, @Nullable String srcName) {
 		this.srcMemberSubName = srcName;
 		this.argIdx = argPosition;
 		this.lvIndex = lvIndex;
@@ -120,7 +122,7 @@ public final class FlatAsRegularMappingVisitor implements MappingVisitor {
 	}
 
 	@Override
-	public boolean visitMethodVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcName) {
+	public boolean visitMethodVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName) {
 		this.srcMemberSubName = srcName;
 		this.argIdx = lvtRowIndex;
 		this.lvIndex = lvIndex;

--- a/src/main/java/net/fabricmc/mappingio/adapter/ForwardingMappingVisitor.java
+++ b/src/main/java/net/fabricmc/mappingio/adapter/ForwardingMappingVisitor.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingFlag;
 import net.fabricmc.mappingio.MappingVisitor;
@@ -53,7 +55,7 @@ public abstract class ForwardingMappingVisitor implements MappingVisitor {
 	}
 
 	@Override
-	public void visitMetadata(String key, String value) throws IOException {
+	public void visitMetadata(String key, @Nullable String value) throws IOException {
 		next.visitMetadata(key, value);
 	}
 
@@ -68,22 +70,22 @@ public abstract class ForwardingMappingVisitor implements MappingVisitor {
 	}
 
 	@Override
-	public boolean visitField(String srcName, String srcDesc) throws IOException {
+	public boolean visitField(String srcName, @Nullable String srcDesc) throws IOException {
 		return next.visitField(srcName, srcDesc);
 	}
 
 	@Override
-	public boolean visitMethod(String srcName, String srcDesc) throws IOException {
+	public boolean visitMethod(String srcName, @Nullable String srcDesc) throws IOException {
 		return next.visitMethod(srcName, srcDesc);
 	}
 
 	@Override
-	public boolean visitMethodArg(int argPosition, int lvIndex, String srcName) throws IOException {
+	public boolean visitMethodArg(int argPosition, int lvIndex, @Nullable String srcName) throws IOException {
 		return next.visitMethodArg(argPosition, lvIndex, srcName);
 	}
 
 	@Override
-	public boolean visitMethodVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcName) throws IOException {
+	public boolean visitMethodVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName) throws IOException {
 		return next.visitMethodVar(lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcName);
 	}
 

--- a/src/main/java/net/fabricmc/mappingio/adapter/MappingNsCompleter.java
+++ b/src/main/java/net/fabricmc/mappingio/adapter/MappingNsCompleter.java
@@ -22,6 +22,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingVisitor;
 
@@ -87,7 +89,7 @@ public final class MappingNsCompleter extends ForwardingMappingVisitor {
 	}
 
 	@Override
-	public void visitMetadata(String key, String value) throws IOException {
+	public void visitMetadata(String key, @Nullable String value) throws IOException {
 		if (relayHeaderOrMetadata) next.visitMetadata(key, value);
 	}
 
@@ -106,28 +108,28 @@ public final class MappingNsCompleter extends ForwardingMappingVisitor {
 	}
 
 	@Override
-	public boolean visitField(String srcName, String srcDesc) throws IOException {
+	public boolean visitField(String srcName, @Nullable String srcDesc) throws IOException {
 		this.srcName = srcName;
 
 		return next.visitField(srcName, srcDesc);
 	}
 
 	@Override
-	public boolean visitMethod(String srcName, String srcDesc) throws IOException {
+	public boolean visitMethod(String srcName, @Nullable String srcDesc) throws IOException {
 		this.srcName = srcName;
 
 		return next.visitMethod(srcName, srcDesc);
 	}
 
 	@Override
-	public boolean visitMethodArg(int argPosition, int lvIndex, String srcName) throws IOException {
+	public boolean visitMethodArg(int argPosition, int lvIndex, @Nullable String srcName) throws IOException {
 		this.srcName = srcName;
 
 		return next.visitMethodArg(argPosition, lvIndex, srcName);
 	}
 
 	@Override
-	public boolean visitMethodVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcName) throws IOException {
+	public boolean visitMethodVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName) throws IOException {
 		this.srcName = srcName;
 
 		return next.visitMethodVar(lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcName);

--- a/src/main/java/net/fabricmc/mappingio/adapter/MappingSourceNsSwitch.java
+++ b/src/main/java/net/fabricmc/mappingio/adapter/MappingSourceNsSwitch.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingFlag;
 import net.fabricmc.mappingio.MappingUtil;
@@ -127,7 +129,7 @@ public final class MappingSourceNsSwitch extends ForwardingMappingVisitor {
 	}
 
 	@Override
-	public void visitMetadata(String key, String value) throws IOException {
+	public void visitMetadata(String key, @Nullable String value) throws IOException {
 		if (classMapReady && relayHeaderOrMetadata) next.visitMetadata(key, value);
 	}
 
@@ -150,7 +152,7 @@ public final class MappingSourceNsSwitch extends ForwardingMappingVisitor {
 	}
 
 	@Override
-	public boolean visitField(String srcName, String srcDesc) throws IOException {
+	public boolean visitField(String srcName, @Nullable String srcDesc) throws IOException {
 		assert classMapReady;
 		if (passThrough) return next.visitField(srcName, srcDesc);
 
@@ -161,7 +163,7 @@ public final class MappingSourceNsSwitch extends ForwardingMappingVisitor {
 	}
 
 	@Override
-	public boolean visitMethod(String srcName, String srcDesc) throws IOException {
+	public boolean visitMethod(String srcName, @Nullable String srcDesc) throws IOException {
 		assert classMapReady;
 		if (passThrough) return next.visitMethod(srcName, srcDesc);
 
@@ -172,7 +174,7 @@ public final class MappingSourceNsSwitch extends ForwardingMappingVisitor {
 	}
 
 	@Override
-	public boolean visitMethodArg(int argPosition, int lvIndex, String srcName) throws IOException {
+	public boolean visitMethodArg(int argPosition, int lvIndex, @Nullable String srcName) throws IOException {
 		assert classMapReady;
 		if (passThrough) return next.visitMethodArg(argPosition, lvIndex, srcName);
 
@@ -184,7 +186,7 @@ public final class MappingSourceNsSwitch extends ForwardingMappingVisitor {
 	}
 
 	@Override
-	public boolean visitMethodVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcName) throws IOException {
+	public boolean visitMethodVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName) throws IOException {
 		assert classMapReady;
 		if (passThrough) return next.visitMethodVar(lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcName);
 

--- a/src/main/java/net/fabricmc/mappingio/adapter/MissingDescFilter.java
+++ b/src/main/java/net/fabricmc/mappingio/adapter/MissingDescFilter.java
@@ -18,6 +18,8 @@ package net.fabricmc.mappingio.adapter;
 
 import java.io.IOException;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.fabricmc.mappingio.MappingVisitor;
 
 public final class MissingDescFilter extends ForwardingMappingVisitor {
@@ -26,14 +28,14 @@ public final class MissingDescFilter extends ForwardingMappingVisitor {
 	}
 
 	@Override
-	public boolean visitField(String srcName, String srcDesc) throws IOException {
+	public boolean visitField(String srcName, @Nullable String srcDesc) throws IOException {
 		if (srcDesc == null) return false;
 
 		return super.visitField(srcName, srcDesc);
 	}
 
 	@Override
-	public boolean visitMethod(String srcName, String srcDesc) throws IOException {
+	public boolean visitMethod(String srcName, @Nullable String srcDesc) throws IOException {
 		if (srcDesc == null) return false;
 
 		return super.visitMethod(srcName, srcDesc);

--- a/src/main/java/net/fabricmc/mappingio/adapter/RegularAsFlatMappingVisitor.java
+++ b/src/main/java/net/fabricmc/mappingio/adapter/RegularAsFlatMappingVisitor.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.fabricmc.mappingio.FlatMappingVisitor;
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingFlag;
@@ -59,7 +61,7 @@ public final class RegularAsFlatMappingVisitor implements FlatMappingVisitor {
 	}
 
 	@Override
-	public void visitMetadata(String key, String value) throws IOException {
+	public void visitMetadata(String key, @Nullable String value) throws IOException {
 		next.visitMetadata(key, value);
 	}
 
@@ -78,7 +80,7 @@ public final class RegularAsFlatMappingVisitor implements FlatMappingVisitor {
 		return visitClass(srcName, null, dstName);
 	}
 
-	private boolean visitClass(String srcName, String[] dstNames, String dstName) throws IOException {
+	private boolean visitClass(String srcName, @Nullable String[] dstNames, @Nullable String dstName) throws IOException {
 		if (!srcName.equals(lastClass)) {
 			lastClass = srcName;
 			lastMemberName = lastMemberDesc = null;
@@ -90,31 +92,32 @@ public final class RegularAsFlatMappingVisitor implements FlatMappingVisitor {
 	}
 
 	@Override
-	public void visitClassComment(String srcName, String[] dstNames, String comment) throws IOException {
+	public void visitClassComment(String srcName, @Nullable String[] dstNames, String comment) throws IOException {
 		if (!visitClass(srcName, dstNames, null)) return;
 		next.visitComment(MappedElementKind.CLASS, comment);
 	}
 
 	@Override
-	public void visitClassComment(String srcName, String dstName, String comment) throws IOException {
+	public void visitClassComment(String srcName, @Nullable String dstName, String comment) throws IOException {
 		if (!visitClass(srcName, null, dstName)) return;
 		next.visitComment(MappedElementKind.CLASS, comment);
 	}
 
 	@Override
-	public boolean visitField(String srcClsName, String srcName, String srcDesc,
-			String[] dstClsNames, String[] dstNames, String[] dstDescs) throws IOException {
+	public boolean visitField(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String[] dstClsNames, String[] dstNames, @Nullable String[] dstDescs) throws IOException {
 		return visitField(srcClsName, srcName, srcDesc, dstClsNames, dstNames, dstDescs, null, null, null);
 	}
 
 	@Override
-	public boolean visitField(String srcClsName, String srcName, String srcDesc,
-			String dstClsName, String dstName, String dstDesc) throws IOException {
+	public boolean visitField(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String dstClsName, String dstName, @Nullable String dstDesc) throws IOException {
 		return visitField(srcClsName, srcName, srcDesc, null, null, null, dstClsName, dstName, dstDesc);
 	}
 
-	private boolean visitField(String srcClsName, String srcName, String srcDesc,
-			String[] dstClsNames, String[] dstNames, String[] dstDescs, String dstClsName, String dstName, String dstDesc) throws IOException {
+	private boolean visitField(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String[] dstClsNames, @Nullable String[] dstNames, @Nullable String[] dstDescs,
+			@Nullable String dstClsName, @Nullable String dstName, @Nullable String dstDesc) throws IOException {
 		if (!visitClass(srcClsName, dstClsNames, dstClsName)) return false;
 
 		if (!lastMemberIsField || !srcName.equals(lastMemberName) || srcDesc != null && !srcDesc.equals(lastMemberDesc)) {
@@ -129,35 +132,36 @@ public final class RegularAsFlatMappingVisitor implements FlatMappingVisitor {
 	}
 
 	@Override
-	public void visitFieldComment(String srcClsName, String srcName, String srcDesc,
-			String[] dstClsNames, String[] dstNames, String[] dstDescs,
+	public void visitFieldComment(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String[] dstClsNames, @Nullable String[] dstNames, @Nullable String[] dstDescs,
 			String comment) throws IOException {
 		if (!visitField(srcClsName, srcName, srcDesc, dstClsNames, dstNames, dstDescs, null, null, null)) return;
 		next.visitComment(MappedElementKind.FIELD, comment);
 	}
 
 	@Override
-	public void visitFieldComment(String srcClsName, String srcName, String srcDesc,
-			String dstClsName, String dstName, String dstDesc,
+	public void visitFieldComment(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String dstClsName, @Nullable String dstName, @Nullable String dstDesc,
 			String comment) throws IOException {
 		if (!visitField(srcClsName, srcName, srcDesc, null, null, null, dstClsName, dstName, dstDesc)) return;
 		next.visitComment(MappedElementKind.FIELD, comment);
 	}
 
 	@Override
-	public boolean visitMethod(String srcClsName, String srcName, String srcDesc,
-			String[] dstClsNames, String[] dstNames, String[] dstDescs) throws IOException {
+	public boolean visitMethod(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String[] dstClsNames, String[] dstNames, @Nullable String[] dstDescs) throws IOException {
 		return visitMethod(srcClsName, srcName, srcDesc, dstClsNames, dstNames, dstDescs, null, null, null);
 	}
 
 	@Override
-	public boolean visitMethod(String srcClsName, String srcName, String srcDesc,
-			String dstClsName, String dstName, String dstDesc) throws IOException {
+	public boolean visitMethod(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String dstClsName, String dstName, @Nullable String dstDesc) throws IOException {
 		return visitMethod(srcClsName, srcName, srcDesc, null, null, null, dstClsName, dstName, dstDesc);
 	}
 
-	private boolean visitMethod(String srcClsName, String srcName, String srcDesc,
-			String[] dstClsNames, String[] dstNames, String[] dstDescs, String dstClsName, String dstName, String dstDesc) throws IOException {
+	private boolean visitMethod(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String[] dstClsNames, @Nullable String[] dstNames, @Nullable String[] dstDescs,
+			@Nullable String dstClsName, @Nullable String dstName, @Nullable String dstDesc) throws IOException {
 		if (!visitClass(srcClsName, dstClsNames, dstClsName)) return false;
 
 		if (lastMemberIsField || !srcName.equals(lastMemberName) || srcDesc != null && !srcDesc.equals(lastMemberDesc)) {
@@ -172,41 +176,45 @@ public final class RegularAsFlatMappingVisitor implements FlatMappingVisitor {
 	}
 
 	@Override
-	public void visitMethodComment(String srcClsName, String srcName, String srcDesc,
-			String[] dstClsNames, String[] dstNames, String[] dstDescs,
+	public void visitMethodComment(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String[] dstClsNames, @Nullable String[] dstNames, @Nullable String[] dstDescs,
 			String comment) throws IOException {
 		if (!visitMethod(srcClsName, srcName, srcDesc, dstClsNames, dstNames, dstDescs, null, null, null)) return;
 		next.visitComment(MappedElementKind.METHOD, comment);
 	}
 
 	@Override
-	public void visitMethodComment(String srcClsName, String srcName, String srcDesc,
-			String dstClsName, String dstName, String dstDesc,
+	public void visitMethodComment(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String dstClsName, @Nullable String dstName, @Nullable String dstDesc,
 			String comment) throws IOException {
 		if (!visitMethod(srcClsName, srcName, srcDesc, null, null, null, dstClsName, dstName, dstDesc)) return;
 		next.visitComment(MappedElementKind.METHOD, comment);
 	}
 
 	@Override
-	public boolean visitMethodArg(String srcClsName, String srcMethodName, String srcMethodDesc,
-			int argPosition, int lvIndex, String srcArgName,
-			String[] dstClsNames, String[] dstMethodNames, String[] dstMethodDescs, String[] dstArgNames) throws IOException {
+	public boolean visitMethodArg(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int argPosition, int lvIndex, @Nullable String srcArgName,
+			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames,
+			@Nullable String[] dstMethodDescs, String[] dstArgNames) throws IOException {
 		return visitMethodArg(srcClsName, srcMethodName, srcMethodDesc, argPosition, lvIndex, srcArgName,
 				dstClsNames, dstMethodNames, dstMethodDescs, dstArgNames, null, null, null, null);
 	}
 
 	@Override
-	public boolean visitMethodArg(String srcClsName, String srcMethodName, String srcMethodDesc,
-			int argPosition, int lvIndex, String srcArgName,
-			String dstClsName, String dstMethodName, String dstMethodDesc, String dstArgName) throws IOException {
+	public boolean visitMethodArg(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int argPosition, int lvIndex, @Nullable String srcArgName,
+			@Nullable String dstClsName, @Nullable String dstMethodName,
+			@Nullable String dstMethodDesc, String dstArgName) throws IOException {
 		return visitMethodArg(srcClsName, srcMethodName, srcMethodDesc, argPosition, lvIndex, srcArgName,
 				null, null, null, null, dstClsName, dstMethodName, dstMethodDesc, dstArgName);
 	}
 
-	private boolean visitMethodArg(String srcClsName, String srcMethodName, String srcMethodDesc,
-			int argPosition, int lvIndex, String srcName,
-			String[] dstClsNames, String[] dstMethodNames, String[] dstMethodDescs, String[] dstNames,
-			String dstClsName, String dstMethodName, String dstMethodDesc, String dstName) throws IOException {
+	private boolean visitMethodArg(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int argPosition, int lvIndex, @Nullable String srcName,
+			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames,
+			@Nullable String[] dstMethodDescs, @Nullable String[] dstNames,
+			@Nullable String dstClsName, @Nullable String dstMethodName,
+			@Nullable String dstMethodDesc, @Nullable String dstName) throws IOException {
 		if (!visitMethod(srcClsName, srcMethodName, srcMethodDesc, dstClsNames, dstMethodNames, dstMethodDescs, dstClsName, dstMethodName, dstMethodDesc)) return false;
 
 		if (!lastMethodSubIsArg || argPosition != lastArgPosition || lvIndex != lastLvIndex) {
@@ -220,9 +228,10 @@ public final class RegularAsFlatMappingVisitor implements FlatMappingVisitor {
 	}
 
 	@Override
-	public void visitMethodArgComment(String srcClsName, String srcMethodName, String srcMethodDesc, int argPosition, int lvIndex, String srcArgName,
-			String[] dstClsNames, String[] dstMethodNames, String[] dstMethodDescs, String[] dstArgNames,
-			String comment) throws IOException {
+	public void visitMethodArgComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int argPosition, int lvIndex, @Nullable String srcArgName,
+			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames,
+			@Nullable String[] dstMethodDescs, @Nullable String[] dstArgNames, String comment) throws IOException {
 		if (!visitMethodArg(srcClsName, srcMethodName, srcMethodDesc, argPosition, lvIndex, srcArgName,
 				dstClsNames, dstMethodNames, dstMethodDescs, dstArgNames, null, null, null, null)) {
 			return;
@@ -232,9 +241,10 @@ public final class RegularAsFlatMappingVisitor implements FlatMappingVisitor {
 	}
 
 	@Override
-	public void visitMethodArgComment(String srcClsName, String srcMethodName, String srcMethodDesc, int argPosition,
-			int lvIndex, String srcArgName, String dstClsName, String dstMethodName, String dstMethodDesc,
-			String dstArgName, String comment) throws IOException {
+	public void visitMethodArgComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int argPosition, int lvIndex, @Nullable String srcArgName,
+			@Nullable String dstClsName, @Nullable String dstMethodName,
+			@Nullable String dstMethodDesc, @Nullable String dstArgName, String comment) throws IOException {
 		if (!visitMethodArg(srcClsName, srcMethodName, srcMethodDesc, argPosition, lvIndex, srcArgName,
 				null, null, null, null, dstClsName, dstMethodName, dstMethodDesc, dstArgName)) {
 			return;
@@ -244,23 +254,27 @@ public final class RegularAsFlatMappingVisitor implements FlatMappingVisitor {
 	}
 
 	@Override
-	public boolean visitMethodVar(String srcClsName, String srcMethodName, String srcMethodDesc, int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcVarName,
-			String[] dstClsNames, String[] dstMethodNames, String[] dstMethodDescs, String[] dstVarNames) throws IOException {
+	public boolean visitMethodVar(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcVarName,
+			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames,
+			@Nullable String[] dstMethodDescs, String[] dstVarNames) throws IOException {
 		return visitMethodVar(srcClsName, srcMethodName, srcMethodDesc, lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcVarName,
 				dstClsNames, dstMethodNames, dstMethodDescs, dstVarNames, null, null, null, null);
 	}
 
 	@Override
-	public boolean visitMethodVar(String srcClsName, String srcMethodName, String srcMethodDesc, int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcVarName,
-			String dstClsName, String dstMethodName, String dstMethodDesc, String dstVarName) throws IOException {
+	public boolean visitMethodVar(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcVarName,
+			@Nullable String dstClsName, @Nullable String dstMethodName,
+			@Nullable String dstMethodDesc, String dstVarName) throws IOException {
 		return visitMethodVar(srcClsName, srcMethodName, srcMethodDesc, lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcVarName,
 				null, null, null, null, dstClsName, dstMethodName, dstMethodDesc, dstVarName);
 	}
 
-	private boolean visitMethodVar(String srcClsName, String srcMethodName, String srcMethodDesc,
-			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcName,
-			String[] dstClsNames, String[] dstMethodNames, String[] dstMethodDescs, String[] dstNames,
-			String dstClsName, String dstMethodName, String dstMethodDesc, String dstName) throws IOException {
+	private boolean visitMethodVar(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName,
+			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames, @Nullable String[] dstMethodDescs, @Nullable String[] dstNames,
+			@Nullable String dstClsName, @Nullable String dstMethodName, @Nullable String dstMethodDesc, @Nullable String dstName) throws IOException {
 		if (!visitMethod(srcClsName, srcMethodName, srcMethodDesc, dstClsNames, dstMethodNames, dstMethodDescs, dstClsName, dstMethodName, dstMethodDesc)) return false;
 
 		if (lastMethodSubIsArg || lvtRowIndex != lastArgPosition || lvIndex != lastLvIndex || startOpIdx != lastStartOpIdx) {
@@ -275,10 +289,10 @@ public final class RegularAsFlatMappingVisitor implements FlatMappingVisitor {
 	}
 
 	@Override
-	public void visitMethodVarComment(String srcClsName, String srcMethodName, String srcMethodDesc,
-			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcVarName,
-			String[] dstClsNames, String[] dstMethodNames, String[] dstMethodDescs, String[] dstVarNames,
-			String comment) throws IOException {
+	public void visitMethodVarComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcVarName,
+			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames, @Nullable String[] dstMethodDescs,
+			@Nullable String[] dstVarNames, String comment) throws IOException {
 		if (!visitMethodVar(srcClsName, srcMethodName, srcMethodDesc, lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcVarName,
 				dstClsNames, dstMethodNames, dstMethodDescs, dstVarNames, null, null, null, null)) {
 			return;
@@ -288,10 +302,10 @@ public final class RegularAsFlatMappingVisitor implements FlatMappingVisitor {
 	}
 
 	@Override
-	public void visitMethodVarComment(String srcClsName, String srcMethodName, String srcMethodDesc,
-			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcVarName,
-			String dstClsName, String dstMethodName, String dstMethodDesc, String dstVarName,
-			String comment) throws IOException {
+	public void visitMethodVarComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcVarName,
+			@Nullable String dstClsName, @Nullable String dstMethodName, @Nullable String dstMethodDesc,
+			@Nullable String dstVarName, String comment) throws IOException {
 		if (!visitMethodVar(srcClsName, srcMethodName, srcMethodDesc, lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcVarName,
 				null, null, null, null, dstClsName, dstMethodName, dstMethodDesc, dstVarName)) {
 			return;
@@ -305,7 +319,7 @@ public final class RegularAsFlatMappingVisitor implements FlatMappingVisitor {
 		return next.visitEnd();
 	}
 
-	private boolean visitDstNames(MappedElementKind targetKind, String[] dstNames, String dstName) throws IOException {
+	private boolean visitDstNames(MappedElementKind targetKind, @Nullable String[] dstNames, @Nullable String dstName) throws IOException {
 		if (dstNames != null) {
 			for (int i = 0; i < dstNames.length; i++) {
 				String name = dstNames[i];
@@ -318,7 +332,8 @@ public final class RegularAsFlatMappingVisitor implements FlatMappingVisitor {
 		return next.visitElementContent(targetKind);
 	}
 
-	private boolean visitDstNamesDescs(MappedElementKind targetKind, String[] dstNames, String[] dstDescs, String dstName, String dstDesc) throws IOException {
+	private boolean visitDstNamesDescs(MappedElementKind targetKind, @Nullable String[] dstNames,
+			@Nullable String[] dstDescs, @Nullable String dstName, @Nullable String dstDesc) throws IOException {
 		boolean relayMemberDesc = targetKind == MappedElementKind.FIELD && relayDstFieldDescs
 				|| targetKind != MappedElementKind.FIELD && relayDstMethodDescs;
 

--- a/src/main/java/net/fabricmc/mappingio/format/ColumnFileReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/ColumnFileReader.java
@@ -22,6 +22,7 @@ import java.io.Reader;
 import java.util.Arrays;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 import net.fabricmc.mappingio.format.tiny.Tiny2Util;
 
@@ -82,6 +83,7 @@ public final class ColumnFileReader implements Closeable {
 	/**
 	 * Read and consume a column without unescaping.
 	 */
+	@Nullable
 	public String nextCol() throws IOException {
 		return nextCol(false);
 	}
@@ -89,6 +91,7 @@ public final class ColumnFileReader implements Closeable {
 	/**
 	 * Read and consume a column with unescaping.
 	 */
+	@Nullable
 	public String nextEscapedCol() throws IOException {
 		return nextCol(true);
 	}
@@ -96,6 +99,7 @@ public final class ColumnFileReader implements Closeable {
 	/**
 	 * Read and consume a column and unescape it if requested.
 	 */
+	@Nullable
 	public String nextCol(boolean unescape) throws IOException {
 		if (eol) return null;
 
@@ -157,6 +161,7 @@ public final class ColumnFileReader implements Closeable {
 	/**
 	 * Read and consume all column until eol and unescape if requested.
 	 */
+	@Nullable
 	public String nextCols(boolean unescape) throws IOException {
 		if (eol) return null;
 

--- a/src/main/java/net/fabricmc/mappingio/format/MappingFormat.java
+++ b/src/main/java/net/fabricmc/mappingio/format/MappingFormat.java
@@ -160,6 +160,7 @@ public enum MappingFormat {
 	}
 
 	public final String name;
+	@Nullable
 	public final String fileExt;
 	public final boolean hasNamespaces;
 	public final boolean hasFieldDescriptors;

--- a/src/main/java/net/fabricmc/mappingio/format/MappingFormat.java
+++ b/src/main/java/net/fabricmc/mappingio/format/MappingFormat.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.mappingio.format;
 
+import org.jetbrains.annotations.Nullable;
+
 /**
  * Represents a supported mapping format. Feature comparison table:
  * <table>
@@ -135,7 +137,7 @@ public enum MappingFormat {
 	 */
 	PROGUARD_FILE("ProGuard file", "txt", false, true, false, false, false);
 
-	MappingFormat(String name, String fileExt,
+	MappingFormat(String name, @Nullable String fileExt,
 			boolean hasNamespaces, boolean hasFieldDescriptors,
 			boolean supportsComments, boolean supportsArgs, boolean supportsLocals) {
 		this.name = name;

--- a/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaWriterBase.java
+++ b/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaWriterBase.java
@@ -22,6 +22,8 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingFlag;
 import net.fabricmc.mappingio.MappingWriter;
@@ -51,7 +53,7 @@ abstract class EnigmaWriterBase implements MappingWriter {
 	}
 
 	@Override
-	public boolean visitField(String srcName, String srcDesc) throws IOException {
+	public boolean visitField(String srcName, @Nullable String srcDesc) throws IOException {
 		writeIndent(0);
 		writer.write("FIELD ");
 		writer.write(srcName);
@@ -62,7 +64,7 @@ abstract class EnigmaWriterBase implements MappingWriter {
 	}
 
 	@Override
-	public boolean visitMethod(String srcName, String srcDesc) throws IOException {
+	public boolean visitMethod(String srcName, @Nullable String srcDesc) throws IOException {
 		writeIndent(0);
 		writer.write("METHOD ");
 		writer.write(srcName);
@@ -73,7 +75,7 @@ abstract class EnigmaWriterBase implements MappingWriter {
 	}
 
 	@Override
-	public boolean visitMethodArg(int argPosition, int lvIndex, String srcName) throws IOException {
+	public boolean visitMethodArg(int argPosition, int lvIndex, @Nullable String srcName) throws IOException {
 		writeIndent(1);
 		writer.write("ARG ");
 		writer.write(Integer.toString(lvIndex));
@@ -82,7 +84,7 @@ abstract class EnigmaWriterBase implements MappingWriter {
 	}
 
 	@Override
-	public boolean visitMethodVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcName) {
+	public boolean visitMethodVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName) {
 		return false;
 	}
 

--- a/src/main/java/net/fabricmc/mappingio/format/proguard/ProGuardFileWriter.java
+++ b/src/main/java/net/fabricmc/mappingio/format/proguard/ProGuardFileWriter.java
@@ -21,6 +21,7 @@ import java.io.Writer;
 import java.util.List;
 import java.util.Objects;
 
+import org.jetbrains.annotations.Nullable;
 import org.objectweb.asm.Type;
 
 import net.fabricmc.mappingio.MappedElementKind;
@@ -109,7 +110,7 @@ public final class ProGuardFileWriter implements MappingWriter {
 	}
 
 	@Override
-	public boolean visitField(String srcName, String srcDesc) throws IOException {
+	public boolean visitField(String srcName, @Nullable String srcDesc) throws IOException {
 		writeIndent();
 		writer.write(toJavaType(srcDesc));
 		writer.write(' ');
@@ -119,7 +120,7 @@ public final class ProGuardFileWriter implements MappingWriter {
 	}
 
 	@Override
-	public boolean visitMethod(String srcName, String srcDesc) throws IOException {
+	public boolean visitMethod(String srcName, @Nullable String srcDesc) throws IOException {
 		Type type = Type.getMethodType(srcDesc);
 		writeIndent();
 		writer.write(toJavaType(type.getReturnType().getDescriptor()));
@@ -142,13 +143,13 @@ public final class ProGuardFileWriter implements MappingWriter {
 	}
 
 	@Override
-	public boolean visitMethodArg(int argPosition, int lvIndex, String srcName) throws IOException {
+	public boolean visitMethodArg(int argPosition, int lvIndex, @Nullable String srcName) throws IOException {
 		// ignored
 		return false;
 	}
 
 	@Override
-	public boolean visitMethodVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcName) throws IOException {
+	public boolean visitMethodVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName) throws IOException {
 		// ignored
 		return false;
 	}

--- a/src/main/java/net/fabricmc/mappingio/format/tiny/Tiny1FileWriter.java
+++ b/src/main/java/net/fabricmc/mappingio/format/tiny/Tiny1FileWriter.java
@@ -23,6 +23,8 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingFlag;
 import net.fabricmc.mappingio.MappingWriter;
@@ -58,7 +60,7 @@ public final class Tiny1FileWriter implements MappingWriter {
 	}
 
 	@Override
-	public void visitMetadata(String key, String value) throws IOException {
+	public void visitMetadata(String key, @Nullable String value) throws IOException {
 		switch (key) {
 		case Tiny1FileReader.nextIntermediaryClassProperty:
 		case Tiny1FileReader.nextIntermediaryFieldProperty:
@@ -93,7 +95,7 @@ public final class Tiny1FileWriter implements MappingWriter {
 	}
 
 	@Override
-	public boolean visitField(String srcName, String srcDesc) throws IOException {
+	public boolean visitField(String srcName, @Nullable String srcDesc) throws IOException {
 		memberSrcName = srcName;
 		memberSrcDesc = srcDesc;
 
@@ -101,7 +103,7 @@ public final class Tiny1FileWriter implements MappingWriter {
 	}
 
 	@Override
-	public boolean visitMethod(String srcName, String srcDesc) throws IOException {
+	public boolean visitMethod(String srcName, @Nullable String srcDesc) throws IOException {
 		memberSrcName = srcName;
 		memberSrcDesc = srcDesc;
 
@@ -109,12 +111,12 @@ public final class Tiny1FileWriter implements MappingWriter {
 	}
 
 	@Override
-	public boolean visitMethodArg(int argPosition, int lvIndex, String srcName) throws IOException {
+	public boolean visitMethodArg(int argPosition, int lvIndex, @Nullable String srcName) throws IOException {
 		return false; // not supported, skip
 	}
 
 	@Override
-	public boolean visitMethodVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcName) throws IOException {
+	public boolean visitMethodVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName) throws IOException {
 		return false; // not supported, skip
 	}
 

--- a/src/main/java/net/fabricmc/mappingio/format/tiny/Tiny2FileWriter.java
+++ b/src/main/java/net/fabricmc/mappingio/format/tiny/Tiny2FileWriter.java
@@ -23,6 +23,8 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingFlag;
 import net.fabricmc.mappingio.MappingWriter;
@@ -59,7 +61,7 @@ public final class Tiny2FileWriter implements MappingWriter {
 	}
 
 	@Override
-	public void visitMetadata(String key, String value) throws IOException {
+	public void visitMetadata(String key, @Nullable String value) throws IOException {
 		if (key.equals(Tiny2Util.escapedNamesProperty)) {
 			escapeNames = true;
 			wroteEscapedNamesProperty = true;
@@ -96,7 +98,7 @@ public final class Tiny2FileWriter implements MappingWriter {
 	}
 
 	@Override
-	public boolean visitField(String srcName, String srcDesc) throws IOException {
+	public boolean visitField(String srcName, @Nullable String srcDesc) throws IOException {
 		write("\tf\t");
 		writeName(srcDesc);
 		writeTab();
@@ -106,7 +108,7 @@ public final class Tiny2FileWriter implements MappingWriter {
 	}
 
 	@Override
-	public boolean visitMethod(String srcName, String srcDesc) throws IOException {
+	public boolean visitMethod(String srcName, @Nullable String srcDesc) throws IOException {
 		write("\tm\t");
 		writeName(srcDesc);
 		writeTab();
@@ -116,7 +118,7 @@ public final class Tiny2FileWriter implements MappingWriter {
 	}
 
 	@Override
-	public boolean visitMethodArg(int argPosition, int lvIndex, String srcName) throws IOException {
+	public boolean visitMethodArg(int argPosition, int lvIndex, @Nullable String srcName) throws IOException {
 		write("\t\tp\t");
 		write(lvIndex);
 		writeTab();
@@ -126,7 +128,7 @@ public final class Tiny2FileWriter implements MappingWriter {
 	}
 
 	@Override
-	public boolean visitMethodVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcName) throws IOException {
+	public boolean visitMethodVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName) throws IOException {
 		write("\t\tv\t");
 		write(lvIndex);
 		writeTab();

--- a/src/main/java/net/fabricmc/mappingio/tree/ClassAnalysisDescCompleter.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/ClassAnalysisDescCompleter.java
@@ -32,6 +32,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
 import java.util.Locale;
 
+import org.jetbrains.annotations.Nullable;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
@@ -142,7 +143,7 @@ public final class ClassAnalysisDescCompleter {
 	}
 
 	private static final class AnalyzingVisitor extends ClassVisitor {
-		AnalyzingVisitor(String namespace, MappingTree mappingTree) {
+		AnalyzingVisitor(@Nullable String namespace, MappingTree mappingTree) {
 			super(Integer.getInteger("mappingIo.asmApiVersion", Opcodes.ASM9));
 
 			this.namespace = namespace != null ? mappingTree.getNamespaceId(namespace) : MappingTreeView.SRC_NAMESPACE_ID;
@@ -157,6 +158,7 @@ public final class ClassAnalysisDescCompleter {
 		}
 
 		@Override
+		@Nullable
 		public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
 			if (cls != null) {
 				FieldMapping field = cls.getField(name, descriptor, namespace);
@@ -170,6 +172,7 @@ public final class ClassAnalysisDescCompleter {
 		}
 
 		@Override
+		@Nullable
 		public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
 			if (cls != null) {
 				MethodMapping method = cls.getMethod(name, descriptor, namespace);

--- a/src/main/java/net/fabricmc/mappingio/tree/HierarchyInfoProvider.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/HierarchyInfoProvider.java
@@ -25,10 +25,23 @@ import net.fabricmc.mappingio.tree.MappingTreeView.MethodMappingView;
 
 public interface HierarchyInfoProvider<T> {
 	String getNamespace();
-	String resolveField(String owner, String name, @Nullable String desc); // returns actual owner or null
-	String resolveMethod(String owner, String name, @Nullable String desc); // returns actual owner or null
+
+	/**
+	 * @return The internal name of the owner class highest up in the hierarchy.
+	 */
+	@Nullable
+	String resolveField(String owner, String name, @Nullable String desc);
+
+	/**
+	 * @return The internal name of the owner class highest up in the hierarchy.
+	 */
+	@Nullable
+	String resolveMethod(String owner, String name, @Nullable String desc);
+
+	@Nullable
 	T getMethodHierarchy(String owner, String name, @Nullable String desc);
 
+	@Nullable
 	default T getMethodHierarchy(MethodMappingView method) {
 		int nsId = method.getTree().getNamespaceId(getNamespace());
 		if (nsId == MappingTreeView.NULL_NAMESPACE_ID) throw new IllegalArgumentException("disassociated namespace");

--- a/src/main/java/net/fabricmc/mappingio/tree/HierarchyInfoProvider.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/HierarchyInfoProvider.java
@@ -18,14 +18,16 @@ package net.fabricmc.mappingio.tree;
 
 import java.util.Collection;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.fabricmc.mappingio.tree.MappingTree.MethodMapping;
 import net.fabricmc.mappingio.tree.MappingTreeView.MethodMappingView;
 
 public interface HierarchyInfoProvider<T> {
 	String getNamespace();
-	String resolveField(String owner, String name, String desc); // returns actual owner or null
-	String resolveMethod(String owner, String name, String desc); // returns actual owner or null
-	T getMethodHierarchy(String owner, String name, String desc);
+	String resolveField(String owner, String name, @Nullable String desc); // returns actual owner or null
+	String resolveMethod(String owner, String name, @Nullable String desc); // returns actual owner or null
+	T getMethodHierarchy(String owner, String name, @Nullable String desc);
 
 	default T getMethodHierarchy(MethodMappingView method) {
 		int nsId = method.getTree().getNamespaceId(getNamespace());
@@ -35,7 +37,7 @@ public interface HierarchyInfoProvider<T> {
 		String name = method.getName(nsId);
 		String desc = method.getDesc(nsId);
 
-		if (owner == null || name == null || desc == null) {
+		if (owner == null || name == null) {
 			return null;
 		} else {
 			return getMethodHierarchy(owner, name, desc);

--- a/src/main/java/net/fabricmc/mappingio/tree/MappingTree.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MappingTree.java
@@ -19,6 +19,8 @@ package net.fabricmc.mappingio.tree;
 import java.util.Collection;
 import java.util.List;
 
+import org.jetbrains.annotations.Nullable;
+
 public interface MappingTree extends MappingTreeView {
 	String setSrcNamespace(String namespace);
 	List<String> setDstNamespaces(List<String> namespaces);
@@ -60,23 +62,23 @@ public interface MappingTree extends MappingTreeView {
 	ClassMapping removeClass(String srcName);
 
 	@Override
-	default FieldMapping getField(String srcOwnerName, String srcName, String srcDesc) {
-		return (FieldMapping) MappingTreeView.super.getField(srcOwnerName, srcName, srcDesc);
+	default FieldMapping getField(String srcClsName, String srcName, @Nullable String srcDesc) {
+		return (FieldMapping) MappingTreeView.super.getField(srcClsName, srcName, srcDesc);
 	}
 
 	@Override
-	default FieldMapping getField(String ownerName, String name, String desc, int namespace) {
-		return (FieldMapping) MappingTreeView.super.getField(ownerName, name, desc, namespace);
+	default FieldMapping getField(String clsName, String name, @Nullable String desc, int namespace) {
+		return (FieldMapping) MappingTreeView.super.getField(clsName, name, desc, namespace);
 	}
 
 	@Override
-	default MethodMapping getMethod(String srcOwnerName, String srcName, String srcDesc) {
-		return (MethodMapping) MappingTreeView.super.getMethod(srcOwnerName, srcName, srcDesc);
+	default MethodMapping getMethod(String srcClsName, String srcName, @Nullable String srcDesc) {
+		return (MethodMapping) MappingTreeView.super.getMethod(srcClsName, srcName, srcDesc);
 	}
 
 	@Override
-	default MethodMapping getMethod(String ownerName, String name, String desc, int namespace) {
-		return (MethodMapping) MappingTreeView.super.getMethod(ownerName, name, desc, namespace);
+	default MethodMapping getMethod(String clsName, String name, @Nullable String desc, int namespace) {
+		return (MethodMapping) MappingTreeView.super.getMethod(clsName, name, desc, namespace);
 	}
 
 	interface MetadataEntry extends MetadataEntryView {
@@ -94,28 +96,28 @@ public interface MappingTree extends MappingTreeView {
 		@Override
 		Collection<? extends FieldMapping> getFields();
 		@Override
-		FieldMapping getField(String srcName, String srcDesc);
+		FieldMapping getField(String srcName, @Nullable String srcDesc);
 
 		@Override
-		default FieldMapping getField(String name, String desc, int namespace) {
+		default FieldMapping getField(String name, @Nullable String desc, int namespace) {
 			return (FieldMapping) ClassMappingView.super.getField(name, desc, namespace);
 		}
 
 		FieldMapping addField(FieldMapping field);
-		FieldMapping removeField(String srcName, String srcDesc);
+		FieldMapping removeField(String srcName, @Nullable String srcDesc);
 
 		@Override
 		Collection<? extends MethodMapping> getMethods();
 		@Override
-		MethodMapping getMethod(String srcName, String srcDesc);
+		MethodMapping getMethod(String srcName, @Nullable String srcDesc);
 
 		@Override
-		default MethodMapping getMethod(String name, String desc, int namespace) {
+		default MethodMapping getMethod(String name, @Nullable String desc, int namespace) {
 			return (MethodMapping) ClassMappingView.super.getMethod(name, desc, namespace);
 		}
 
 		MethodMapping addMethod(MethodMapping method);
-		MethodMapping removeMethod(String srcName, String srcDesc);
+		MethodMapping removeMethod(String srcName, @Nullable String srcDesc);
 	}
 
 	interface MemberMapping extends ElementMapping, MemberMappingView {
@@ -130,16 +132,16 @@ public interface MappingTree extends MappingTreeView {
 		@Override
 		Collection<? extends MethodArgMapping> getArgs();
 		@Override
-		MethodArgMapping getArg(int argPosition, int lvIndex, String srcName);
+		MethodArgMapping getArg(int argPosition, int lvIndex, @Nullable String srcName);
 		MethodArgMapping addArg(MethodArgMapping arg);
-		MethodArgMapping removeArg(int argPosition, int lvIndex, String srcName);
+		MethodArgMapping removeArg(int argPosition, int lvIndex, @Nullable String srcName);
 
 		@Override
 		Collection<? extends MethodVarMapping> getVars();
 		@Override
-		MethodVarMapping getVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcName);
+		MethodVarMapping getVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName);
 		MethodVarMapping addVar(MethodVarMapping var);
-		MethodVarMapping removeVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcName);
+		MethodVarMapping removeVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName);
 	}
 
 	interface MethodArgMapping extends ElementMapping, MethodArgMappingView {

--- a/src/main/java/net/fabricmc/mappingio/tree/MappingTree.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MappingTree.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.jetbrains.annotations.Nullable;
 
 public interface MappingTree extends MappingTreeView {
+	@Nullable
 	String setSrcNamespace(String namespace);
 	List<String> setDstNamespaces(List<String> namespaces);
 
@@ -51,32 +52,39 @@ public interface MappingTree extends MappingTreeView {
 	@Override
 	Collection<? extends ClassMapping> getClasses();
 	@Override
+	@Nullable
 	ClassMapping getClass(String srcName);
 
 	@Override
+	@Nullable
 	default ClassMapping getClass(String name, int namespace) {
 		return (ClassMapping) MappingTreeView.super.getClass(name, namespace);
 	}
 
 	ClassMapping addClass(ClassMapping cls);
+	@Nullable
 	ClassMapping removeClass(String srcName);
 
 	@Override
+	@Nullable
 	default FieldMapping getField(String srcClsName, String srcName, @Nullable String srcDesc) {
 		return (FieldMapping) MappingTreeView.super.getField(srcClsName, srcName, srcDesc);
 	}
 
 	@Override
+	@Nullable
 	default FieldMapping getField(String clsName, String name, @Nullable String desc, int namespace) {
 		return (FieldMapping) MappingTreeView.super.getField(clsName, name, desc, namespace);
 	}
 
 	@Override
+	@Nullable
 	default MethodMapping getMethod(String srcClsName, String srcName, @Nullable String srcDesc) {
 		return (MethodMapping) MappingTreeView.super.getMethod(srcClsName, srcName, srcDesc);
 	}
 
 	@Override
+	@Nullable
 	default MethodMapping getMethod(String clsName, String name, @Nullable String desc, int namespace) {
 		return (MethodMapping) MappingTreeView.super.getMethod(clsName, name, desc, namespace);
 	}
@@ -96,27 +104,33 @@ public interface MappingTree extends MappingTreeView {
 		@Override
 		Collection<? extends FieldMapping> getFields();
 		@Override
+		@Nullable
 		FieldMapping getField(String srcName, @Nullable String srcDesc);
 
 		@Override
+		@Nullable
 		default FieldMapping getField(String name, @Nullable String desc, int namespace) {
 			return (FieldMapping) ClassMappingView.super.getField(name, desc, namespace);
 		}
 
 		FieldMapping addField(FieldMapping field);
+		@Nullable
 		FieldMapping removeField(String srcName, @Nullable String srcDesc);
 
 		@Override
 		Collection<? extends MethodMapping> getMethods();
 		@Override
+		@Nullable
 		MethodMapping getMethod(String srcName, @Nullable String srcDesc);
 
 		@Override
+		@Nullable
 		default MethodMapping getMethod(String name, @Nullable String desc, int namespace) {
 			return (MethodMapping) ClassMappingView.super.getMethod(name, desc, namespace);
 		}
 
 		MethodMapping addMethod(MethodMapping method);
+		@Nullable
 		MethodMapping removeMethod(String srcName, @Nullable String srcDesc);
 	}
 
@@ -132,15 +146,19 @@ public interface MappingTree extends MappingTreeView {
 		@Override
 		Collection<? extends MethodArgMapping> getArgs();
 		@Override
+		@Nullable
 		MethodArgMapping getArg(int argPosition, int lvIndex, @Nullable String srcName);
 		MethodArgMapping addArg(MethodArgMapping arg);
+		@Nullable
 		MethodArgMapping removeArg(int argPosition, int lvIndex, @Nullable String srcName);
 
 		@Override
 		Collection<? extends MethodVarMapping> getVars();
 		@Override
+		@Nullable
 		MethodVarMapping getVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName);
 		MethodVarMapping addVar(MethodVarMapping var);
+		@Nullable
 		MethodVarMapping removeVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName);
 	}
 

--- a/src/main/java/net/fabricmc/mappingio/tree/MappingTreeView.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MappingTreeView.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.fabricmc.mappingio.MappingVisitor;
 
 public interface MappingTreeView {
@@ -74,32 +76,29 @@ public interface MappingTreeView {
 	/**
 	 * @see MappingTreeView#getField(String, String, String, int)
 	 */
-	default FieldMappingView getField(String srcOwnerName, String srcName, String srcDesc) {
-		ClassMappingView owner = getClass(srcOwnerName);
+	default FieldMappingView getField(String srcClsName, String srcName, @Nullable String srcDesc) {
+		ClassMappingView owner = getClass(srcClsName);
 		return owner != null ? owner.getField(srcName, srcDesc) : null;
 	}
 
-	/**
-	 * @param desc Nullable.
-	 */
-	default FieldMappingView getField(String ownerName, String name, String desc, int namespace) {
-		ClassMappingView owner = getClass(ownerName, namespace);
+	default FieldMappingView getField(String clsName, String name, @Nullable String desc, int namespace) {
+		ClassMappingView owner = getClass(clsName, namespace);
 		return owner != null ? owner.getField(name, desc, namespace) : null;
 	}
 
 	/**
 	 * @see MappingTreeView#getMethod(String, String, String, int)
 	 */
-	default MethodMappingView getMethod(String srcOwnerName, String srcName, String srcDesc) {
-		ClassMappingView owner = getClass(srcOwnerName);
+	default MethodMappingView getMethod(String srcClsName, String srcName, @Nullable String srcDesc) {
+		ClassMappingView owner = getClass(srcClsName);
 		return owner != null ? owner.getMethod(srcName, srcDesc) : null;
 	}
 
 	/**
-	 * @param desc Nullable. Can be either complete desc or parameter-only desc.
+	 * @param desc Can be either complete desc or parameter-only desc.
 	 */
-	default MethodMappingView getMethod(String ownerName, String name, String desc, int namespace) {
-		ClassMappingView owner = getClass(ownerName, namespace);
+	default MethodMappingView getMethod(String clsName, String name, @Nullable String desc, int namespace) {
+		ClassMappingView owner = getClass(clsName, namespace);
 		return owner != null ? owner.getMethod(name, desc, namespace) : null;
 	}
 
@@ -219,12 +218,12 @@ public interface MappingTreeView {
 		/**
 		 * @see MappingTreeView#getField(String, String, String, int)
 		 */
-		FieldMappingView getField(String srcName, String srcDesc);
+		FieldMappingView getField(String srcName, @Nullable String srcDesc);
 
 		/**
 		 * @see MappingTreeView#getField(String, String, String, int)
 		 */
-		default FieldMappingView getField(String name, String desc, int namespace) {
+		default FieldMappingView getField(String name, @Nullable String desc, int namespace) {
 			if (namespace < 0) return getField(name, desc);
 
 			for (FieldMappingView field : getFields()) {
@@ -243,12 +242,12 @@ public interface MappingTreeView {
 		/**
 		 * @see MappingTreeView#getMethod(String, String, String, int)
 		 */
-		MethodMappingView getMethod(String srcName, String srcDesc);
+		MethodMappingView getMethod(String srcName, @Nullable String srcDesc);
 
 		/**
 		 * @see MappingTreeView#getMethod(String, String, String, int)
 		 */
-		default MethodMappingView getMethod(String name, String desc, int namespace) {
+		default MethodMappingView getMethod(String name, @Nullable String desc, int namespace) {
 			if (namespace < 0) return getMethod(name, desc);
 
 			for (MethodMappingView method : getMethods()) {
@@ -299,10 +298,10 @@ public interface MappingTreeView {
 
 	interface MethodMappingView extends MemberMappingView {
 		Collection<? extends MethodArgMappingView> getArgs();
-		MethodArgMappingView getArg(int argPosition, int lvIndex, String srcName);
+		MethodArgMappingView getArg(int argPosition, int lvIndex, @Nullable String srcName);
 
 		Collection<? extends MethodVarMappingView> getVars();
-		MethodVarMappingView getVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcName);
+		MethodVarMappingView getVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName);
 	}
 
 	interface MethodArgMappingView extends ElementMappingView {

--- a/src/main/java/net/fabricmc/mappingio/tree/MappingTreeView.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MappingTreeView.java
@@ -25,7 +25,16 @@ import org.jetbrains.annotations.Nullable;
 import net.fabricmc.mappingio.MappingVisitor;
 
 public interface MappingTreeView {
+	/**
+	 * @return The source namespace, or {@code null} if the tree is uninitialized.
+	 */
+	@Nullable
 	String getSrcNamespace();
+
+	/**
+	 * @return A list containing the destination namespaces, in order of their IDs.
+	 * Can only be empty if the tree is uninitialized.
+	 */
 	List<String> getDstNamespaces();
 
 	/**
@@ -62,7 +71,9 @@ public interface MappingTreeView {
 	List<? extends MetadataEntryView> getMetadata(String key);
 
 	Collection<? extends ClassMappingView> getClasses();
+	@Nullable
 	ClassMappingView getClass(String srcName);
+	@Nullable
 	default ClassMappingView getClass(String name, int namespace) {
 		if (namespace < 0) return getClass(name);
 
@@ -76,11 +87,13 @@ public interface MappingTreeView {
 	/**
 	 * @see MappingTreeView#getField(String, String, String, int)
 	 */
+	@Nullable
 	default FieldMappingView getField(String srcClsName, String srcName, @Nullable String srcDesc) {
 		ClassMappingView owner = getClass(srcClsName);
 		return owner != null ? owner.getField(srcName, srcDesc) : null;
 	}
 
+	@Nullable
 	default FieldMappingView getField(String clsName, String name, @Nullable String desc, int namespace) {
 		ClassMappingView owner = getClass(clsName, namespace);
 		return owner != null ? owner.getField(name, desc, namespace) : null;
@@ -89,6 +102,7 @@ public interface MappingTreeView {
 	/**
 	 * @see MappingTreeView#getMethod(String, String, String, int)
 	 */
+	@Nullable
 	default MethodMappingView getMethod(String srcClsName, String srcName, @Nullable String srcDesc) {
 		ClassMappingView owner = getClass(srcClsName);
 		return owner != null ? owner.getMethod(srcName, srcDesc) : null;
@@ -97,6 +111,7 @@ public interface MappingTreeView {
 	/**
 	 * @param desc Can be either complete desc or parameter-only desc.
 	 */
+	@Nullable
 	default MethodMappingView getMethod(String clsName, String name, @Nullable String desc, int namespace) {
 		ClassMappingView owner = getClass(clsName, namespace);
 		return owner != null ? owner.getMethod(name, desc, namespace) : null;
@@ -182,6 +197,7 @@ public interface MappingTreeView {
 
 	interface MetadataEntryView {
 		String getKey();
+		@Nullable
 		String getValue();
 	}
 
@@ -189,8 +205,10 @@ public interface MappingTreeView {
 		MappingTreeView getTree();
 
 		String getSrcName();
+		@Nullable
 		String getDstName(int namespace);
 
+		@Nullable
 		default String getName(int namespace) {
 			if (namespace < 0) {
 				return getSrcName();
@@ -199,6 +217,7 @@ public interface MappingTreeView {
 			}
 		}
 
+		@Nullable
 		default String getName(String namespace) {
 			int nsId = getTree().getNamespaceId(namespace);
 
@@ -209,6 +228,7 @@ public interface MappingTreeView {
 			}
 		}
 
+		@Nullable
 		String getComment();
 	}
 
@@ -218,11 +238,13 @@ public interface MappingTreeView {
 		/**
 		 * @see MappingTreeView#getField(String, String, String, int)
 		 */
+		@Nullable
 		FieldMappingView getField(String srcName, @Nullable String srcDesc);
 
 		/**
 		 * @see MappingTreeView#getField(String, String, String, int)
 		 */
+		@Nullable
 		default FieldMappingView getField(String name, @Nullable String desc, int namespace) {
 			if (namespace < 0) return getField(name, desc);
 
@@ -242,11 +264,13 @@ public interface MappingTreeView {
 		/**
 		 * @see MappingTreeView#getMethod(String, String, String, int)
 		 */
+		@Nullable
 		MethodMappingView getMethod(String srcName, @Nullable String srcDesc);
 
 		/**
 		 * @see MappingTreeView#getMethod(String, String, String, int)
 		 */
+		@Nullable
 		default MethodMappingView getMethod(String name, @Nullable String desc, int namespace) {
 			if (namespace < 0) return getMethod(name, desc);
 
@@ -265,14 +289,17 @@ public interface MappingTreeView {
 
 	interface MemberMappingView extends ElementMappingView {
 		ClassMappingView getOwner();
+		@Nullable
 		String getSrcDesc();
 
+		@Nullable
 		default String getDstDesc(int namespace) {
 			String srcDesc = getSrcDesc();
 
 			return srcDesc != null ? getTree().mapDesc(srcDesc, namespace) : null;
 		}
 
+		@Nullable
 		default String getDesc(int namespace) {
 			String srcDesc = getSrcDesc();
 
@@ -283,6 +310,7 @@ public interface MappingTreeView {
 			}
 		}
 
+		@Nullable
 		default String getDesc(String namespace) {
 			int nsId = getTree().getNamespaceId(namespace);
 
@@ -298,9 +326,11 @@ public interface MappingTreeView {
 
 	interface MethodMappingView extends MemberMappingView {
 		Collection<? extends MethodArgMappingView> getArgs();
+		@Nullable
 		MethodArgMappingView getArg(int argPosition, int lvIndex, @Nullable String srcName);
 
 		Collection<? extends MethodVarMappingView> getVars();
+		@Nullable
 		MethodVarMappingView getVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName);
 	}
 

--- a/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
@@ -102,11 +102,13 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 	}
 
 	@Override
+	@Nullable
 	public String getSrcNamespace() {
 		return srcNamespace;
 	}
 
 	@Override
+	@Nullable
 	public String setSrcNamespace(String namespace) {
 		String ret = srcNamespace;
 		srcNamespace = namespace;
@@ -236,11 +238,13 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 	}
 
 	@Override
+	@Nullable
 	public ClassMapping getClass(String srcName) {
 		return classesBySrcName.get(srcName);
 	}
 
 	@Override
+	@Nullable
 	public ClassMapping getClass(String name, int namespace) {
 		if (namespace < 0 || !indexByDstNames) {
 			return VisitableMappingTree.super.getClass(name, namespace);
@@ -277,6 +281,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 	}
 
 	@Override
+	@Nullable
 	public ClassMapping removeClass(String srcName) {
 		ClassEntry ret = classesBySrcName.remove(srcName);
 
@@ -728,6 +733,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
+		@Nullable
 		public final String getDstName(int namespace) {
 			return dstNames[namespace];
 		}
@@ -756,6 +762,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
+		@Nullable
 		public final String getComment() {
 			return comment;
 		}
@@ -869,11 +876,13 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
+		@Nullable
 		public FieldEntry getField(String srcName, @Nullable String srcDesc) {
 			return getMember(srcName, srcDesc, fields, flags, FLAG_HAS_ANY_FIELD_DESC, FLAG_MISSES_ANY_FIELD_DESC);
 		}
 
 		@Override
+		@Nullable
 		public FieldEntry getField(String name, @Nullable String desc, int namespace) {
 			return (FieldEntry) ClassMapping.super.getField(name, desc, namespace);
 		}
@@ -888,6 +897,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
+		@Nullable
 		public FieldEntry removeField(String srcName, @Nullable String srcDesc) {
 			FieldEntry ret = getField(srcName, srcDesc);
 			if (ret != null) fields.remove(ret.key);
@@ -903,11 +913,13 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
+		@Nullable
 		public MethodEntry getMethod(String srcName, @Nullable String srcDesc) {
 			return getMember(srcName, srcDesc, methods, flags, FLAG_HAS_ANY_METHOD_DESC, FLAG_MISSES_ANY_METHOD_DESC);
 		}
 
 		@Override
+		@Nullable
 		public MethodEntry getMethod(String name, @Nullable String desc, int namespace) {
 			return (MethodEntry) ClassMapping.super.getMethod(name, desc, namespace);
 		}
@@ -922,6 +934,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
+		@Nullable
 		public MethodEntry removeMethod(String srcName, @Nullable String srcDesc) {
 			MethodEntry ret = getMethod(srcName, srcDesc);
 			if (ret != null) methods.remove(ret.key);
@@ -1144,6 +1157,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
+		@Nullable
 		public final String getSrcDesc() {
 			return srcDesc;
 		}
@@ -1264,6 +1278,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
+		@Nullable
 		public MethodArgEntry getArg(int argPosition, int lvIndex, @Nullable String srcName) {
 			if (args == null) return null;
 
@@ -1312,6 +1327,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
+		@Nullable
 		public MethodArgEntry removeArg(int argPosition, int lvIndex, @Nullable String srcName) {
 			MethodArgEntry ret = getArg(argPosition, lvIndex, srcName);
 			if (ret != null) args.remove(ret);
@@ -1327,6 +1343,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
+		@Nullable
 		public MethodVarEntry getVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName) {
 			if (vars == null) return null;
 
@@ -1426,6 +1443,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
+		@Nullable
 		public MethodVarEntry removeVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName) {
 			MethodVarEntry ret = getVar(lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcName);
 			if (ret != null) vars.remove(ret);

--- a/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
@@ -33,6 +33,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingFlag;
 import net.fabricmc.mappingio.MappingVisitor;
@@ -91,7 +93,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 	}
 
-	public void setHierarchyInfoProvider(HierarchyInfoProvider<?> provider) {
+	public void setHierarchyInfoProvider(@Nullable HierarchyInfoProvider<?> provider) {
 		hierarchyInfo = provider;
 
 		if (provider != null) {
@@ -398,7 +400,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 	}
 
 	@Override
-	public void visitMetadata(String key, String value) {
+	public void visitMetadata(String key, @Nullable String value) {
 		MetadataEntryImpl entry = new MetadataEntryImpl(key, value);
 		addMetadata(entry);
 	}
@@ -425,7 +427,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 	}
 
 	@Override
-	public boolean visitField(String srcName, String srcDesc) {
+	public boolean visitField(String srcName, @Nullable String srcDesc) {
 		if (currentClass == null) throw new UnsupportedOperationException("Tried to visit field before owning class");
 
 		currentMethod = null;
@@ -449,7 +451,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 	}
 
 	@Override
-	public boolean visitMethod(String srcName, String srcDesc) {
+	public boolean visitMethod(String srcName, @Nullable String srcDesc) {
 		if (currentClass == null) throw new UnsupportedOperationException("Tried to visit method before owning class");
 
 		MethodEntry method = currentClass.getMethod(srcName, srcDesc, srcNsMap);
@@ -470,7 +472,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		return true;
 	}
 
-	private MemberEntry<?> queuePendingMember(String name, String desc, boolean isField) {
+	private MemberEntry<?> queuePendingMember(String name, @Nullable String desc, boolean isField) {
 		if (pendingMembers == null) pendingMembers = new HashMap<>();
 		GlobalMemberKey key = new GlobalMemberKey(currentClass, name, desc, isField);
 		MemberEntry<?> member = pendingMembers.get(key);
@@ -523,7 +525,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 	}
 
 	@Override
-	public boolean visitMethodArg(int argPosition, int lvIndex, String srcName) {
+	public boolean visitMethodArg(int argPosition, int lvIndex, @Nullable String srcName) {
 		if (currentMethod == null) throw new UnsupportedOperationException("Tried to visit method argument before owning method");
 
 		MethodArgEntry arg = currentMethod.getArg(argPosition, lvIndex, srcName);
@@ -547,7 +549,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 	}
 
 	@Override
-	public boolean visitMethodVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcName) {
+	public boolean visitMethodVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName) {
 		if (currentMethod == null) throw new UnsupportedOperationException("Tried to visit method variable before owning method");
 
 		MethodVarEntry var = currentMethod.getVar(lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcName);
@@ -763,7 +765,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 			this.comment = comment;
 		}
 
-		protected final boolean acceptElement(MappingVisitor visitor, String[] dstDescs) throws IOException {
+		protected final boolean acceptElement(MappingVisitor visitor, @Nullable String[] dstDescs) throws IOException {
 			MappedElementKind kind = getKind();
 
 			for (int i = 0; i < dstNames.length; i++) {
@@ -867,12 +869,12 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
-		public FieldEntry getField(String srcName, String srcDesc) {
+		public FieldEntry getField(String srcName, @Nullable String srcDesc) {
 			return getMember(srcName, srcDesc, fields, flags, FLAG_HAS_ANY_FIELD_DESC, FLAG_MISSES_ANY_FIELD_DESC);
 		}
 
 		@Override
-		public FieldEntry getField(String name, String desc, int namespace) {
+		public FieldEntry getField(String name, @Nullable String desc, int namespace) {
 			return (FieldEntry) ClassMapping.super.getField(name, desc, namespace);
 		}
 
@@ -886,7 +888,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
-		public FieldEntry removeField(String srcName, String srcDesc) {
+		public FieldEntry removeField(String srcName, @Nullable String srcDesc) {
 			FieldEntry ret = getField(srcName, srcDesc);
 			if (ret != null) fields.remove(ret.key);
 
@@ -901,12 +903,12 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
-		public MethodEntry getMethod(String srcName, String srcDesc) {
+		public MethodEntry getMethod(String srcName, @Nullable String srcDesc) {
 			return getMember(srcName, srcDesc, methods, flags, FLAG_HAS_ANY_METHOD_DESC, FLAG_MISSES_ANY_METHOD_DESC);
 		}
 
 		@Override
-		public MethodEntry getMethod(String name, String desc, int namespace) {
+		public MethodEntry getMethod(String name, @Nullable String desc, int namespace) {
 			return (MethodEntry) ClassMapping.super.getMethod(name, desc, namespace);
 		}
 
@@ -920,14 +922,15 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
-		public MethodEntry removeMethod(String srcName, String srcDesc) {
+		public MethodEntry removeMethod(String srcName, @Nullable String srcDesc) {
 			MethodEntry ret = getMethod(srcName, srcDesc);
 			if (ret != null) methods.remove(ret.key);
 
 			return ret;
 		}
 
-		private static <T extends MemberEntry<T>> T getMember(String srcName, String srcDesc, Map<MemberKey, T> map, int flags, int flagHasAny, int flagMissesAny) {
+		private static <T extends MemberEntry<T>> T getMember(String srcName, @Nullable String srcDesc,
+				@Nullable Map<MemberKey, T> map, int flags, int flagHasAny, int flagMissesAny) {
 			if (map == null) return null;
 
 			boolean hasAnyDesc = (flags & flagHasAny) != 0;
@@ -1114,7 +1117,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 	}
 
 	abstract static class MemberEntry<T extends MemberEntry<T>> extends Entry<T> implements MemberMapping {
-		protected MemberEntry(ClassEntry owner, String srcName, String srcDesc) {
+		protected MemberEntry(ClassEntry owner, String srcName, @Nullable String srcDesc) {
 			super(owner.tree, srcName);
 
 			this.owner = owner;
@@ -1168,7 +1171,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 	}
 
 	static final class FieldEntry extends MemberEntry<FieldEntry> implements FieldMapping {
-		FieldEntry(ClassEntry owner, String srcName, String srcDesc) {
+		FieldEntry(ClassEntry owner, String srcName, @Nullable String srcDesc) {
 			super(owner, srcName, srcDesc);
 		}
 
@@ -1182,7 +1185,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
-		public void setSrcDesc(String desc) {
+		public void setSrcDesc(@Nullable String desc) {
 			if (Objects.equals(desc, srcDesc)) return;
 
 			MemberKey newKey = new MemberKey(srcName, desc);
@@ -1213,7 +1216,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 	}
 
 	static final class MethodEntry extends MemberEntry<MethodEntry> implements MethodMapping {
-		MethodEntry(ClassEntry owner, String srcName, String srcDesc) {
+		MethodEntry(ClassEntry owner, String srcName, @Nullable String srcDesc) {
 			super(owner, srcName, srcDesc);
 		}
 
@@ -1235,7 +1238,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
-		public void setSrcDesc(String desc) {
+		public void setSrcDesc(@Nullable String desc) {
 			if (Objects.equals(desc, srcDesc)) return;
 
 			MemberKey newKey = new MemberKey(srcName, desc);
@@ -1261,7 +1264,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
-		public MethodArgEntry getArg(int argPosition, int lvIndex, String srcName) {
+		public MethodArgEntry getArg(int argPosition, int lvIndex, @Nullable String srcName) {
 			if (args == null) return null;
 
 			if (argPosition >= 0 || lvIndex >= 0) {
@@ -1309,7 +1312,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
-		public MethodArgEntry removeArg(int argPosition, int lvIndex, String srcName) {
+		public MethodArgEntry removeArg(int argPosition, int lvIndex, @Nullable String srcName) {
 			MethodArgEntry ret = getArg(argPosition, lvIndex, srcName);
 			if (ret != null) args.remove(ret);
 
@@ -1324,7 +1327,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
-		public MethodVarEntry getVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcName) {
+		public MethodVarEntry getVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName) {
 			if (vars == null) return null;
 
 			if (lvtRowIndex >= 0) {
@@ -1423,7 +1426,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
-		public MethodVarEntry removeVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcName) {
+		public MethodVarEntry removeVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName) {
 			MethodVarEntry ret = getVar(lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcName);
 			if (ret != null) vars.remove(ret);
 
@@ -1493,7 +1496,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 	}
 
 	static final class MethodArgEntry extends Entry<MethodArgEntry> implements MethodArgMapping {
-		MethodArgEntry(MethodEntry method, int argPosition, int lvIndex, String srcName) {
+		MethodArgEntry(MethodEntry method, int argPosition, int lvIndex, @Nullable String srcName) {
 			super(method.owner.tree, srcName);
 
 			this.method = method;
@@ -1544,7 +1547,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 			this.lvIndex = index;
 		}
 
-		public void setSrcName(String name) {
+		public void setSrcName(@Nullable String name) {
 			this.srcName = name;
 		}
 
@@ -1574,7 +1577,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 	}
 
 	static final class MethodVarEntry extends Entry<MethodVarEntry> implements MethodVarMapping {
-		MethodVarEntry(MethodEntry method, int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcName) {
+		MethodVarEntry(MethodEntry method, int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName) {
 			super(method.owner.tree, srcName);
 
 			this.method = method;
@@ -1641,7 +1644,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 			this.endOpIdx = endOpIdx;
 		}
 
-		public void setSrcName(String name) {
+		public void setSrcName(@Nullable String name) {
 			this.srcName = name;
 		}
 
@@ -1673,7 +1676,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 	}
 
 	static final class MemberKey {
-		MemberKey(String name, String desc) {
+		MemberKey(String name, @Nullable String desc) {
 			this.name = name;
 			this.desc = desc;
 
@@ -1709,7 +1712,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 	}
 
 	static final class MetadataEntryImpl implements MetadataEntry {
-		MetadataEntryImpl(String key, String value) {
+		MetadataEntryImpl(String key, @Nullable String value) {
 			this.key = key;
 			this.value = value;
 		}
@@ -1752,7 +1755,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 	}
 
 	static final class GlobalMemberKey {
-		GlobalMemberKey(ClassEntry owner, String name, String desc, boolean isField) {
+		GlobalMemberKey(ClassEntry owner, String name, @Nullable String desc, boolean isField) {
 			this.owner = owner;
 			this.name = name;
 			this.desc = desc;

--- a/src/main/java/net/fabricmc/mappingio/tree/TinyRemapperHierarchyProvider.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/TinyRemapperHierarchyProvider.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.fabricmc.mappingio.tree.MappingTreeView.MethodMappingView;
 import net.fabricmc.mappingio.tree.TinyRemapperHierarchyProvider.HierarchyData;
 import net.fabricmc.tinyremapper.api.TrClass;
@@ -45,7 +47,7 @@ public final class TinyRemapperHierarchyProvider implements HierarchyInfoProvide
 	}
 
 	@Override
-	public String resolveField(String owner, String name, String desc) {
+	public String resolveField(String owner, String name, @Nullable String desc) {
 		TrClass cls = env.getClass(owner);
 		if (cls == null) return null;
 
@@ -55,7 +57,9 @@ public final class TinyRemapperHierarchyProvider implements HierarchyInfoProvide
 	}
 
 	@Override
-	public String resolveMethod(String owner, String name, String desc) {
+	public String resolveMethod(String owner, String name, @Nullable String desc) {
+		if (desc == null) return null; // TODO: Tiny Remapper limitation
+
 		TrClass cls = env.getClass(owner);
 		if (cls == null) return null;
 
@@ -65,7 +69,9 @@ public final class TinyRemapperHierarchyProvider implements HierarchyInfoProvide
 	}
 
 	@Override
-	public HierarchyData getMethodHierarchy(String owner, String name, String desc) {
+	public HierarchyData getMethodHierarchy(String owner, String name, @Nullable String desc) {
+		if (desc == null) return null; // TODO: Tiny Remapper limitation
+
 		TrClass cls = env.getClass(owner);
 		if (cls == null) return null;
 
@@ -129,12 +135,12 @@ public final class TinyRemapperHierarchyProvider implements HierarchyInfoProvide
 	}
 
 	@Override
-	public int getHierarchySize(HierarchyData hierarchy) {
+	public int getHierarchySize(@Nullable HierarchyData hierarchy) {
 		return hierarchy != null ? hierarchy.methods.size() : 0;
 	}
 
 	@Override
-	public Collection<? extends MethodMappingView> getHierarchyMethods(HierarchyData hierarchy, MappingTreeView tree) {
+	public Collection<? extends MethodMappingView> getHierarchyMethods(@Nullable HierarchyData hierarchy, MappingTreeView tree) {
 		if (hierarchy == null) return Collections.emptyList();
 
 		List<MethodMappingView> ret = new ArrayList<>(hierarchy.methods.size());

--- a/src/main/java/net/fabricmc/mappingio/tree/TinyRemapperHierarchyProvider.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/TinyRemapperHierarchyProvider.java
@@ -47,6 +47,7 @@ public final class TinyRemapperHierarchyProvider implements HierarchyInfoProvide
 	}
 
 	@Override
+	@Nullable
 	public String resolveField(String owner, String name, @Nullable String desc) {
 		TrClass cls = env.getClass(owner);
 		if (cls == null) return null;
@@ -57,6 +58,7 @@ public final class TinyRemapperHierarchyProvider implements HierarchyInfoProvide
 	}
 
 	@Override
+	@Nullable
 	public String resolveMethod(String owner, String name, @Nullable String desc) {
 		if (desc == null) return null; // TODO: Tiny Remapper limitation
 
@@ -69,6 +71,7 @@ public final class TinyRemapperHierarchyProvider implements HierarchyInfoProvide
 	}
 
 	@Override
+	@Nullable
 	public HierarchyData getMethodHierarchy(String owner, String name, @Nullable String desc) {
 		if (desc == null) return null; // TODO: Tiny Remapper limitation
 

--- a/src/main/java/net/fabricmc/mappingio/tree/VisitOrder.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/VisitOrder.java
@@ -21,6 +21,8 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.fabricmc.mappingio.tree.MappingTreeView.ClassMappingView;
 import net.fabricmc.mappingio.tree.MappingTreeView.ElementMappingView;
 import net.fabricmc.mappingio.tree.MappingTreeView.FieldMappingView;
@@ -154,13 +156,13 @@ public final class VisitOrder {
 		return (a, b) -> compareShortFirst(a.getSrcName(), b.getSrcName());
 	}
 
-	public static int compare(String a, String b) {
+	public static int compare(@Nullable String a, @Nullable String b) {
 		if (a == null || b == null) return compareNullLast(a, b);
 
 		return a.compareTo(b);
 	}
 
-	public static int compareShortFirst(String a, String b) {
+	public static int compareShortFirst(@Nullable String a, @Nullable String b) {
 		if (a == null || b == null) return compareNullLast(a, b);
 
 		int cmp = a.length() - b.length();
@@ -185,7 +187,7 @@ public final class VisitOrder {
 		return 0;
 	}
 
-	public static int byNameShortFirstNestaware(String a, String b) {
+	public static int byNameShortFirstNestaware(@Nullable String a, @Nullable String b) {
 		if (a == null || b == null) {
 			return compareNullLast(a, b);
 		}
@@ -211,7 +213,7 @@ public final class VisitOrder {
 		return 0;
 	}
 
-	public static int compareNullLast(String a, String b) {
+	public static int compareNullLast(@Nullable String a, @Nullable String b) {
 		if (a == null) {
 			if (b == null) { // both null
 				return 0;

--- a/src/test/java/net/fabricmc/mappingio/NopMappingVisitor.java
+++ b/src/test/java/net/fabricmc/mappingio/NopMappingVisitor.java
@@ -19,6 +19,8 @@ package net.fabricmc.mappingio;
 import java.io.IOException;
 import java.util.List;
 
+import org.jetbrains.annotations.Nullable;
+
 public class NopMappingVisitor implements MappingVisitor {
 	public NopMappingVisitor(boolean visitSubVisitors) {
 		this.visitSubVisitors = visitSubVisitors;
@@ -44,22 +46,22 @@ public class NopMappingVisitor implements MappingVisitor {
 	}
 
 	@Override
-	public boolean visitField(String srcName, String srcDesc) throws IOException {
+	public boolean visitField(String srcName, @Nullable String srcDesc) throws IOException {
 		return visitSubVisitors;
 	}
 
 	@Override
-	public boolean visitMethod(String srcName, String srcDesc) throws IOException {
+	public boolean visitMethod(String srcName, @Nullable String srcDesc) throws IOException {
 		return visitSubVisitors;
 	}
 
 	@Override
-	public boolean visitMethodArg(int argPosition, int lvIndex, String srcName) throws IOException {
+	public boolean visitMethodArg(int argPosition, int lvIndex, @Nullable String srcName) throws IOException {
 		return visitSubVisitors;
 	}
 
 	@Override
-	public boolean visitMethodVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, String srcName) throws IOException {
+	public boolean visitMethodVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName) throws IOException {
 		return visitSubVisitors;
 	}
 

--- a/src/test/java/net/fabricmc/mappingio/read/ValidContentReadTest.java
+++ b/src/test/java/net/fabricmc/mappingio/read/ValidContentReadTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -133,7 +134,7 @@ public class ValidContentReadTest {
 		return tree;
 	}
 
-	private void assertSubset(MappingTree subTree, MappingFormat subFormat, MappingTree supTree, MappingFormat supFormat) throws Exception {
+	private void assertSubset(MappingTree subTree, @Nullable MappingFormat subFormat, MappingTree supTree, @Nullable MappingFormat supFormat) throws Exception {
 		int supDstNsCount = supTree.getMaxNamespaceId();
 		boolean subHasNamespaces = subFormat == null ? true : subFormat.hasNamespaces;
 		boolean supHasNamespaces = supFormat == null ? true : supFormat.hasNamespaces;

--- a/src/test/java/net/fabricmc/mappingio/tree/MetadataTest.java
+++ b/src/test/java/net/fabricmc/mappingio/tree/MetadataTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -57,7 +58,7 @@ public class MetadataTest {
 	public void testOrder() throws Exception {
 		tree.accept(new NopMappingVisitor(true) {
 			@Override
-			public void visitMetadata(String key, String value) {
+			public void visitMetadata(String key, @Nullable String value) {
 				assertEquals(key, keys.get(visitCount));
 				assertEquals(value, values.get(visitCount));
 				visitCount++;
@@ -76,7 +77,7 @@ public class MetadataTest {
 			}
 
 			@Override
-			public void visitMetadata(String key, String value) {
+			public void visitMetadata(String key, @Nullable String value) {
 				assertFalse(visitedKeys.contains(key));
 				visitedKeys.add(key);
 			}


### PR DESCRIPTION
Clearly defines where consumers must be careful about potential null values and where only non-null values are allowed. Unannotated elements have to be considered null-hostile by default.