### PR TITLE
Optimize Enigma directory reader

### DIFF
--- a/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaDirReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaDirReader.java
@@ -22,10 +22,16 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collections;
+import java.util.Set;
 
+import net.fabricmc.mappingio.MappingFlag;
 import net.fabricmc.mappingio.MappingUtil;
 import net.fabricmc.mappingio.MappingVisitor;
+import net.fabricmc.mappingio.adapter.ForwardingMappingVisitor;
 import net.fabricmc.mappingio.format.MappingFormat;
+import net.fabricmc.mappingio.tree.MappingTree;
+import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
 public final class EnigmaDirReader {
 	private EnigmaDirReader() {
@@ -36,16 +42,58 @@ public final class EnigmaDirReader {
 	}
 
 	public static void read(Path dir, String sourceNs, String targetNs, MappingVisitor visitor) throws IOException {
+		Set<MappingFlag> flags = visitor.getFlags();
+		MappingVisitor parentVisitor = null;
+
+		if (flags.contains(MappingFlag.NEEDS_ELEMENT_UNIQUENESS) || flags.contains(MappingFlag.NEEDS_MULTIPLE_PASSES)) {
+			parentVisitor = visitor;
+			visitor = new MemoryMappingTree();
+		}
+
+		if (visitor.visitHeader()) {
+			visitor.visitNamespaces(sourceNs, Collections.singletonList(targetNs));
+		}
+
+		MappingVisitor delegatingVisitor = new ForwardingMappingVisitor(visitor) {
+			@Override
+			public boolean visitHeader() throws IOException {
+				return false; // Namespaces have already been visited above, and Enigma files don't have any metadata
+			}
+
+			@Override
+			public boolean visitContent() throws IOException {
+				if (!visitedContent) { // Don't call next's visitContent() more than once
+					visitedContent = true;
+					visitContent = super.visitContent();
+				}
+
+				return visitContent;
+			}
+
+			@Override
+			public boolean visitEnd() throws IOException {
+				return true; // Don't forward since we're not done yet, there are more files to come
+			}
+
+			private boolean visitedContent;
+			private boolean visitContent;
+		};
+
 		Files.walkFileTree(dir, new SimpleFileVisitor<Path>() {
 			@Override
 			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
 				if (file.getFileName().toString().endsWith("." + MappingFormat.ENIGMA_FILE.fileExt)) {
-					EnigmaFileReader.read(Files.newBufferedReader(file), sourceNs, targetNs, visitor);
+					EnigmaFileReader.read(Files.newBufferedReader(file), sourceNs, targetNs, delegatingVisitor);
 				}
 
 				return FileVisitResult.CONTINUE;
 			}
 		});
+
 		visitor.visitEnd();
+
+		if (parentVisitor != null) {
+			((MappingTree) visitor).accept(parentVisitor);
+		}
 	}
 }

--- a/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaFileReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaFileReader.java
@@ -50,9 +50,7 @@ public final class EnigmaFileReader {
 			visitor = new MemoryMappingTree();
 		}
 
-		boolean visitHeader = visitor.visitHeader();
-
-		if (visitHeader) {
+		if (visitor.visitHeader()) {
 			visitor.visitNamespaces(sourceNs, Collections.singletonList(targetNs));
 		}
 


### PR DESCRIPTION
No longer instantiates new `MemoryMappingTree`s for each file, doesn't forward inappropriate `visitEnd` calls and skips duplicate `visitNamespaces` invocations (works around the exception that caused https://github.com/FabricMC/fabric-loom/pull/974 to fail).