### PR TITLE
Add test for multiple visit passes

### DIFF
--- a/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaDirReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaDirReader.java
@@ -90,7 +90,11 @@ public final class EnigmaDirReader {
 			}
 		});
 
-		visitor.visitEnd();
+		if (visitor.visitEnd() && parentVisitor == null) return;
+
+		if (parentVisitor == null) {
+			throw new IllegalStateException("repeated visitation requested without NEEDS_MULTIPLE_PASSES");
+		}
 
 		if (parentVisitor != null) {
 			((MappingTree) visitor).accept(parentVisitor);

--- a/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaFileReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaFileReader.java
@@ -65,7 +65,11 @@ public final class EnigmaFileReader {
 			} while (reader.nextLine(0));
 		}
 
-		visitor.visitEnd();
+		if (visitor.visitEnd() && parentVisitor == null) return;
+
+		if (parentVisitor == null) {
+			throw new IllegalStateException("repeated visitation requested without NEEDS_MULTIPLE_PASSES");
+		}
 
 		if (parentVisitor != null) {
 			((MappingTree) visitor).accept(parentVisitor);

--- a/src/test/java/net/fabricmc/mappingio/TestHelper.java
+++ b/src/test/java/net/fabricmc/mappingio/TestHelper.java
@@ -23,6 +23,8 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.fabricmc.mappingio.format.MappingFormat;
 import net.fabricmc.mappingio.tree.MappingTree;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
@@ -33,6 +35,33 @@ public final class TestHelper {
 			return Paths.get(TestHelper.class.getResource(slashPrefixedResourcePath).toURI());
 		} catch (URISyntaxException e) {
 			throw new RuntimeException(e);
+		}
+	}
+
+	@Nullable
+	public static String getFileName(MappingFormat format) {
+		switch (format) {
+		case ENIGMA_FILE:
+			return "enigma.mappings";
+		case ENIGMA_DIR:
+			return "enigma-dir";
+		case TINY_FILE:
+			return "tiny.tiny";
+		case TINY_2_FILE:
+			return "tinyV2.tiny";
+		case SRG_FILE:
+			return "srg.srg";
+		case XSRG_FILE:
+			return "xsrg.xsrg";
+		case CSRG_FILE:
+			return "csrg.csrg";
+		case TSRG_FILE:
+			return "tsrg.tsrg";
+		case TSRG_2_FILE:
+			return "tsrg2.tsrg";
+		case PROGUARD_FILE:
+		default:
+			return null;
 		}
 	}
 
@@ -318,6 +347,12 @@ public final class TestHelper {
 		private ThreadLocal<AtomicInteger> argNum = ThreadLocal.withInitial(() -> new AtomicInteger());
 		private ThreadLocal<AtomicInteger> varNum = ThreadLocal.withInitial(() -> new AtomicInteger());
 		private ThreadLocal<AtomicInteger> nsNum = ThreadLocal.withInitial(() -> new AtomicInteger());
+	}
+
+	public static class MappingDirs {
+		public static final Path DETECTION = getResource("/detection/");
+		public static final Path VALID = getResource("/read/valid/");
+		public static final Path VALID_WITH_HOLES = getResource("/read/valid-with-holes/");
 	}
 
 	private static final String fldDesc = "I";

--- a/src/test/java/net/fabricmc/mappingio/read/DetectionTest.java
+++ b/src/test/java/net/fabricmc/mappingio/read/DetectionTest.java
@@ -25,72 +25,73 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.AssertionFailedError;
 
 import net.fabricmc.mappingio.MappingReader;
+import net.fabricmc.mappingio.NopMappingVisitor;
 import net.fabricmc.mappingio.TestHelper;
 import net.fabricmc.mappingio.format.MappingFormat;
-import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
 public class DetectionTest {
-	private static Path dir;
-
-	@BeforeAll
-	public static void setup() throws Exception {
-		dir = TestHelper.getResource("/detection/");
-	}
+	private static final Path dir = TestHelper.MappingDirs.DETECTION;
 
 	@Test
 	public void enigmaFile() throws Exception {
-		check("enigma.mappings", MappingFormat.ENIGMA_FILE);
+		MappingFormat format = MappingFormat.ENIGMA_FILE;
+		check(format);
 	}
 
 	@Test
 	public void enigmaDirectory() throws Exception {
-		check("enigma-dir", MappingFormat.ENIGMA_DIR);
+		MappingFormat format = MappingFormat.ENIGMA_DIR;
+		check(format);
 	}
 
 	@Test
 	public void tinyFile() throws Exception {
-		check("tiny.tiny", MappingFormat.TINY_FILE);
-		read("tiny.tiny");
+		MappingFormat format = MappingFormat.TINY_FILE;
+		check(format);
 	}
 
 	@Test
 	public void tinyV2File() throws Exception {
-		check("tinyV2.tiny", MappingFormat.TINY_2_FILE);
-		read("tinyV2.tiny");
+		MappingFormat format = MappingFormat.TINY_2_FILE;
+		check(format);
 	}
 
 	@Test
 	public void srgFile() throws Exception {
-		check("srg.srg", MappingFormat.SRG_FILE);
+		MappingFormat format = MappingFormat.SRG_FILE;
+		check(format);
 	}
 
 	@Test
 	public void xrgFile() throws Exception {
-		check("xsrg.xsrg", MappingFormat.XSRG_FILE);
+		MappingFormat format = MappingFormat.XSRG_FILE;
+		check(format);
 	}
 
 	@Test
 	public void csrgFile() throws Exception {
-		assertThrows(AssertionFailedError.class, () -> check("csrg.csrg", MappingFormat.CSRG_FILE));
+		MappingFormat format = MappingFormat.CSRG_FILE;
+		assertThrows(AssertionFailedError.class, () -> check(format));
 	}
 
 	@Test
 	public void tsrgFile() throws Exception {
-		check("tsrg.tsrg", MappingFormat.TSRG_FILE);
+		MappingFormat format = MappingFormat.TSRG_FILE;
+		check(format);
 	}
 
 	@Test
 	public void tsrg2File() throws Exception {
-		check("tsrg2.tsrg", MappingFormat.TSRG_2_FILE);
+		MappingFormat format = MappingFormat.TSRG_2_FILE;
+		check(format);
 	}
 
-	private void check(String file, MappingFormat format) throws Exception {
-		Path path = dir.resolve(file);
+	private void check(MappingFormat format) throws Exception {
+		Path path = dir.resolve(TestHelper.getFileName(format));
 		assertEquals(format, MappingReader.detectFormat(path));
 
 		if (!format.hasSingleFile()) return;
@@ -98,16 +99,10 @@ public class DetectionTest {
 		try (Reader reader = new InputStreamReader(Files.newInputStream(path), StandardCharsets.UTF_8)) {
 			assertEquals(format, MappingReader.detectFormat(reader));
 		}
-	}
 
-	private void read(String file) throws Exception {
-		Path path = dir.resolve(file);
-
-		// Make sure we can read the mappings
-		MemoryMappingTree mappingTree = new MemoryMappingTree();
-
+		// Make sure that the passed reader still works after implicit format detection (see https://github.com/FabricMC/mapping-io/pull/71).
 		try (Reader reader = new InputStreamReader(Files.newInputStream(path), StandardCharsets.UTF_8)) {
-			MappingReader.read(reader, mappingTree);
+			MappingReader.read(reader, new NopMappingVisitor(true));
 		}
 	}
 }

--- a/src/test/java/net/fabricmc/mappingio/read/ValidContentReadTest.java
+++ b/src/test/java/net/fabricmc/mappingio/read/ValidContentReadTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -47,13 +46,11 @@ import net.fabricmc.mappingio.tree.MemoryMappingTree;
 import net.fabricmc.mappingio.tree.VisitableMappingTree;
 
 public class ValidContentReadTest {
-	private static Path dir;
 	private static MappingTree testTree;
 	private static MappingTree testTreeWithHoles;
 
 	@BeforeAll
 	public static void setup() throws Exception {
-		dir = TestHelper.getResource("/read/");
 		testTree = TestHelper.createTestTree();
 		testTreeWithHoles = TestHelper.createTestTreeWithHoles();
 	}
@@ -61,78 +58,69 @@ public class ValidContentReadTest {
 	@Test
 	public void enigmaFile() throws Exception {
 		MappingFormat format = MappingFormat.ENIGMA_FILE;
-		String filename = "enigma.mappings";
-		checkDefault(filename, format);
-		checkHoles(filename, format);
+		checkDefault(format);
+		checkHoles(format);
 	}
 
 	@Test
 	public void enigmaDirectory() throws Exception {
 		MappingFormat format = MappingFormat.ENIGMA_DIR;
-		String filename = "enigma-dir";
-		checkDefault(filename, format);
-		checkHoles(filename, format);
+		checkDefault(format);
+		checkHoles(format);
 	}
 
 	@Test
 	public void tinyFile() throws Exception {
 		MappingFormat format = MappingFormat.TINY_FILE;
-		String filename = "tiny.tiny";
-		checkDefault(filename, format);
-		checkHoles(filename, format);
+		checkDefault(format);
+		checkHoles(format);
 	}
 
 	@Test
 	public void tinyV2File() throws Exception {
 		MappingFormat format = MappingFormat.TINY_2_FILE;
-		String filename = "tinyV2.tiny";
-		checkDefault(filename, format);
-		checkHoles(filename, format);
+		checkDefault(format);
+		checkHoles(format);
 	}
 
 	@Test
 	public void srgFile() throws Exception {
 		MappingFormat format = MappingFormat.SRG_FILE;
-		String filename = "srg.srg";
-		checkDefault(filename, format);
-		checkHoles(filename, format);
+		checkDefault(format);
+		checkHoles(format);
 	}
 
 	@Test
 	public void xsrgFile() throws Exception {
 		MappingFormat format = MappingFormat.XSRG_FILE;
-		String filename = "xsrg.xsrg";
-		checkDefault(filename, format);
-		checkHoles(filename, format);
+		checkDefault(format);
+		checkHoles(format);
 	}
 
 	@Test
 	public void csrgFile() throws Exception {
 		MappingFormat format = MappingFormat.CSRG_FILE;
-		String filename = "csrg.csrg";
-		checkDefault(filename, format);
-		checkHoles(filename, format);
+		checkDefault(format);
+		checkHoles(format);
 	}
 
 	@Test
 	public void tsrgFile() throws Exception {
 		MappingFormat format = MappingFormat.TSRG_FILE;
-		String filename = "tsrg.tsrg";
-		checkDefault(filename, format);
-		checkHoles(filename, format);
+		checkDefault(format);
+		checkHoles(format);
 	}
 
 	@Test
 	public void tsrg2File() throws Exception {
 		MappingFormat format = MappingFormat.TSRG_2_FILE;
-		String filename = "tsrg2.tsrg";
-		checkDefault(filename, format);
-		checkHoles(filename, format);
+		checkDefault(format);
+		checkHoles(format);
 	}
 
-	private VisitableMappingTree checkDefault(String path, MappingFormat format) throws Exception {
+	private VisitableMappingTree checkDefault(MappingFormat format) throws Exception {
 		VisitableMappingTree tree = new MemoryMappingTree();
-		MappingReader.read(dir.resolve("valid/" + path), format, tree);
+		MappingReader.read(TestHelper.MappingDirs.VALID.resolve(TestHelper.getFileName(format)), format, tree);
 
 		assertSubset(tree, format, testTree, null);
 		assertSubset(testTree, null, tree, format);
@@ -140,9 +128,9 @@ public class ValidContentReadTest {
 		return tree;
 	}
 
-	private VisitableMappingTree checkHoles(String path, MappingFormat format) throws Exception {
+	private VisitableMappingTree checkHoles(MappingFormat format) throws Exception {
 		VisitableMappingTree tree = new MemoryMappingTree();
-		MappingReader.read(dir.resolve("valid-with-holes/" + path), format, tree);
+		MappingReader.read(TestHelper.MappingDirs.VALID_WITH_HOLES.resolve(TestHelper.getFileName(format)), format, tree);
 
 		assertSubset(tree, format, testTreeWithHoles, null);
 		assertSubset(testTreeWithHoles, null, tree, format);

--- a/src/test/java/net/fabricmc/mappingio/visiting/VisitEndTest.java
+++ b/src/test/java/net/fabricmc/mappingio/visiting/VisitEndTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2023 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.mappingio.visiting;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import net.fabricmc.mappingio.MappedElementKind;
+import net.fabricmc.mappingio.MappingFlag;
+import net.fabricmc.mappingio.MappingReader;
+import net.fabricmc.mappingio.MappingVisitor;
+import net.fabricmc.mappingio.TestHelper;
+import net.fabricmc.mappingio.format.MappingFormat;
+
+public class VisitEndTest {
+	private static Set<Path> dirs = new HashSet<>();
+
+	@BeforeAll
+	public static void setup() throws Exception {
+		dirs.add(TestHelper.MappingDirs.DETECTION);
+		dirs.add(TestHelper.MappingDirs.VALID);
+		dirs.add(TestHelper.MappingDirs.VALID_WITH_HOLES);
+	}
+
+	@Test
+	public void testVisitEnd() throws Exception {
+		for (MappingFormat format : MappingFormat.values()) {
+			String filename = TestHelper.getFileName(format);
+			if (filename == null) continue;
+
+			for (Path dir : dirs) {
+				MappingReader.read(dir.resolve(filename), format, new VisitEndTestVisitor(1, true));
+				MappingReader.read(dir.resolve(filename), format, new VisitEndTestVisitor(1, false));
+
+				VisitEndTestVisitor threePassVisitor = new VisitEndTestVisitor(2, true);
+				MappingReader.read(dir.resolve(filename), format, threePassVisitor);
+				assertTrue(threePassVisitor.finishedVisitPassCount == threePassVisitor.visitPassCountToFinish);
+
+				threePassVisitor = new VisitEndTestVisitor(2, false);
+
+				try {
+					MappingReader.read(dir.resolve(filename), format, threePassVisitor);
+				} catch (Exception e) {
+					continue; // Reader doesn't support multiple passes without NEEDS_MULTIPLE_PASSES
+				}
+
+				// Reader didn't throw an exception, make sure it actually behaved as expected
+				assertTrue(threePassVisitor.finishedVisitPassCount == threePassVisitor.visitPassCountToFinish);
+			}
+		}
+	}
+
+	private static class VisitEndTestVisitor implements MappingVisitor {
+		private VisitEndTestVisitor(int visitPassCountToFinish, boolean setFlag) {
+			this.visitPassCountToFinish = visitPassCountToFinish;
+			this.setFlag = setFlag;
+		}
+
+		@Override
+		public Set<MappingFlag> getFlags() {
+			return setFlag
+					? EnumSet.of(MappingFlag.NEEDS_MULTIPLE_PASSES)
+					: MappingVisitor.super.getFlags();
+		}
+
+		@Override
+		public boolean visitHeader() throws IOException {
+			check();
+			return true;
+		}
+
+		@Override
+		public void visitNamespaces(String srcNamespace, List<String> dstNamespaces) throws IOException {
+			check();
+		}
+
+		@Override
+		public boolean visitContent() throws IOException {
+			check();
+			return true;
+		}
+
+		@Override
+		public boolean visitClass(String srcName) throws IOException {
+			check();
+			return true;
+		}
+
+		@Override
+		public boolean visitField(String srcName, @Nullable String srcDesc) throws IOException {
+			check();
+			return true;
+		}
+
+		@Override
+		public boolean visitMethod(String srcName, @Nullable String srcDesc) throws IOException {
+			check();
+			return true;
+		}
+
+		@Override
+		public boolean visitMethodArg(int argPosition, int lvIndex, @Nullable String srcName) throws IOException {
+			check();
+			return true;
+		}
+
+		@Override
+		public boolean visitMethodVar(int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName) throws IOException {
+			check();
+			return true;
+		}
+
+		@Override
+		public void visitDstName(MappedElementKind targetKind, int namespace, String name) throws IOException {
+			check();
+		}
+
+		@Override
+		public void visitDstDesc(MappedElementKind targetKind, int namespace, String desc) throws IOException {
+			check();
+		}
+
+		@Override
+		public boolean visitElementContent(MappedElementKind targetKind) throws IOException {
+			check();
+			return true;
+		}
+
+		@Override
+		public void visitComment(MappedElementKind targetKind, String comment) throws IOException {
+			check();
+		}
+
+		@Override
+		public boolean visitEnd() throws IOException {
+			finishedVisitPassCount++;
+			return finishedVisitPassCount == visitPassCountToFinish;
+		}
+
+		private void check() {
+			assertTrue(finishedVisitPassCount < visitPassCountToFinish);
+		}
+
+		private final int visitPassCountToFinish;
+		private final boolean setFlag;
+		private int finishedVisitPassCount;
+	}
+}

--- a/src/test/resources/detection/srg.srg
+++ b/src/test/resources/detection/srg.srg
@@ -1,2 +1,2 @@
 CL: class_1 RenamedClass
-FD: field_1 renamedField
+FD: class_1/field_1 RenamedClass/renamedField

--- a/src/test/resources/detection/xsrg.xsrg
+++ b/src/test/resources/detection/xsrg.xsrg
@@ -1,2 +1,2 @@
 CL: class_1 RenamedClass
-FD: class_1/field_1 Lclass_1; renamedField LRenamedClass;
+FD: class_1/field_1 Lclass_1; RenamedClass/renamedField LRenamedClass;


### PR DESCRIPTION
To make sure that returning `false` in `visitEnd` actually starts a new visit pass.

Also fixes issues with some detection test mappings and streamlines mapping file path resolving.