### PR TITLE
Add `MappingFormat#hasWriter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added `MappingFormat#hasWriter` boolean
 
 ## [0.5.1] - 2023-11-30
 - Improved documentation

--- a/src/main/java/net/fabricmc/mappingio/format/MappingFormat.java
+++ b/src/main/java/net/fabricmc/mappingio/format/MappingFormat.java
@@ -19,7 +19,9 @@ package net.fabricmc.mappingio.format;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Represents a supported mapping format. Feature comparison table:
+ * Represents a supported mapping format. Every format can be assumed to have an associated reader available.
+ *
+ * <p>Feature comparison table:
  * <table>
  *   <tr>
  *     <th>Format</th>
@@ -109,58 +111,59 @@ public enum MappingFormat {
 	/**
 	 * The {@code Tiny} mapping format, as specified <a href="https://fabricmc.net/wiki/documentation:tiny">here</a>.
 	 */
-	TINY_FILE("Tiny file", "tiny", true, true, false, false, false),
+	TINY_FILE("Tiny file", "tiny", true, true, false, false, false, true),
 
 	/**
 	 * The {@code Tiny v2} mapping format, as specified <a href="https://fabricmc.net/wiki/documentation:tiny2">here</a>.
 	 */
-	TINY_2_FILE("Tiny v2 file", "tiny", true, true, true, true, true),
+	TINY_2_FILE("Tiny v2 file", "tiny", true, true, true, true, true, true),
 
 	/**
 	 * Enigma's mapping format, as specified <a href="https://fabricmc.net/wiki/documentation:enigma_mappings">here</a>.
 	 */
-	ENIGMA_FILE("Enigma file", "mapping", false, true, true, true, false),
+	ENIGMA_FILE("Enigma file", "mapping", false, true, true, true, false, true),
 
 	/**
 	 * Enigma's mapping format (in directory form), as specified <a href="https://fabricmc.net/wiki/documentation:enigma_mappings">here</a>.
 	 */
-	ENIGMA_DIR("Enigma directory", null, false, true, true, true, false),
+	ENIGMA_DIR("Enigma directory", null, false, true, true, true, false, true),
 
 	/**
 	 * The {@code SRG} ("Searge RetroGuard") mapping format, as specified <a href="https://github.com/MinecraftForge/SrgUtils/blob/67f30647ece29f18256ca89a23cda6216d6bd21e/src/main/java/net/minecraftforge/srgutils/InternalUtils.java#L69-L81">here</a>.
 	 */
-	SRG_FILE("SRG file", "srg", false, false, false, false, false),
+	SRG_FILE("SRG file", "srg", false, false, false, false, false, true),
 
 	/**
 	 * The {@code XSRG} ("Extended SRG") mapping format, as specified <a href="https://github.com/MinecraftForge/SrgUtils/blob/67f30647ece29f18256ca89a23cda6216d6bd21e/src/main/java/net/minecraftforge/srgutils/InternalUtils.java#L69-L84">here</a>.
 	 * Same as SRG, but with field descriptors.
 	 */
-	XSRG_FILE("XSRG file", "xsrg", false, true, false, false, false),
+	XSRG_FILE("XSRG file", "xsrg", false, true, false, false, false, true),
 
 	/**
 	 * The {@code CSRG} ("Compact SRG", since it saves disk space over SRG) mapping format, as specified <a href="https://github.com/MinecraftForge/SrgUtils/blob/67f30647ece29f18256ca89a23cda6216d6bd21e/src/main/java/net/minecraftforge/srgutils/InternalUtils.java#L196-L207">here</a>.
 	 */
-	CSRG_FILE("CSRG file", "csrg", false, false, false, false, false),
+	CSRG_FILE("CSRG file", "csrg", false, false, false, false, false, false),
 
 	/**
 	 * The {@code TSRG} ("Tiny SRG", since it saves disk space over SRG) mapping format, as specified <a href="https://github.com/MinecraftForge/SrgUtils/blob/67f30647ece29f18256ca89a23cda6216d6bd21e/src/main/java/net/minecraftforge/srgutils/InternalUtils.java#L196-L213">here</a>.
 	 * Same as CSRG, but hierarchical instead of flat.
 	 */
-	TSRG_FILE("TSRG file", "tsrg", false, false, false, false, false),
+	TSRG_FILE("TSRG file", "tsrg", false, false, false, false, false, false),
 
 	/**
 	 * The {@code TSRG v2} mapping format, as specified <a href="https://github.com/MinecraftForge/SrgUtils/blob/67f30647ece29f18256ca89a23cda6216d6bd21e/src/main/java/net/minecraftforge/srgutils/InternalUtils.java#L262-L285">here</a>.
 	 */
-	TSRG_2_FILE("TSRG2 file", "tsrg", true, true, false, true, false),
+	TSRG_2_FILE("TSRG2 file", "tsrg", true, true, false, true, false, false),
 
 	/**
 	 * ProGuard's mapping format, as specified <a href="https://www.guardsquare.com/manual/tools/retrace">here</a>.
 	 */
-	PROGUARD_FILE("ProGuard file", "txt", false, true, false, false, false);
+	PROGUARD_FILE("ProGuard file", "txt", false, true, false, false, false, true);
 
 	MappingFormat(String name, @Nullable String fileExt,
 			boolean hasNamespaces, boolean hasFieldDescriptors,
-			boolean supportsComments, boolean supportsArgs, boolean supportsLocals) {
+			boolean supportsComments, boolean supportsArgs, boolean supportsLocals,
+			boolean hasWriter) {
 		this.name = name;
 		this.fileExt = fileExt;
 		this.hasNamespaces = hasNamespaces;
@@ -168,6 +171,7 @@ public enum MappingFormat {
 		this.supportsComments = supportsComments;
 		this.supportsArgs = supportsArgs;
 		this.supportsLocals = supportsLocals;
+		this.hasWriter = hasWriter;
 	}
 
 	public boolean hasSingleFile() {
@@ -188,4 +192,5 @@ public enum MappingFormat {
 	public final boolean supportsComments;
 	public final boolean supportsArgs;
 	public final boolean supportsLocals;
+	public final boolean hasWriter;
 }


### PR DESCRIPTION
Adds an easy way for querying whether or not a given `MappingFormat` has an associated writer available. This makes it easier for applications like Enigma to display a dropdown with all writable formats, instead of hardcoding the list or erroring after the fact. `MappingWriter#create`'s return value isn't a viable alternative, since you have to pass a valid path or `java.io.Writer` to it before being able to obtain a result.