### PR TITLE
Fix CSRG and JAM writers skipping elements whose parents have incomplete destination names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Fixed CSRG and JAM writers sometimes skipping over elements whose parents are missing destination names
+- Fixed CSRG and JAM writers sometimes skipping elements whose parents have incomplete destination names
 
 ## [0.6.0] - 2024-4-12
 - Added CSRG writer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fixed CSRG and JAM writers sometimes skipping over elements whose parents are missing destination names
 
 ## [0.6.0] - 2024-4-12
 - Added CSRG writer

--- a/src/main/java/net/fabricmc/mappingio/format/srg/CsrgFileWriter.java
+++ b/src/main/java/net/fabricmc/mappingio/format/srg/CsrgFileWriter.java
@@ -93,27 +93,27 @@ public final class CsrgFileWriter implements MappingWriter {
 
 	@Override
 	public boolean visitElementContent(MappedElementKind targetKind) throws IOException {
-		if (dstName == null) return false;
+		if (dstName != null) {
+			write(classSrcName);
 
-		write(classSrcName);
-
-		if (targetKind != MappedElementKind.CLASS) {
-			writeSpace();
-			write(memberSrcName);
-
-			if (targetKind == MappedElementKind.METHOD) {
+			if (targetKind != MappedElementKind.CLASS) {
 				writeSpace();
-				write(methodSrcDesc);
+				write(memberSrcName);
+
+				if (targetKind == MappedElementKind.METHOD) {
+					writeSpace();
+					write(methodSrcDesc);
+				}
+
+				memberSrcName = methodSrcDesc = null;
 			}
 
-			memberSrcName = methodSrcDesc = null;
+			writeSpace();
+			write(dstName);
+			writeLn();
+
+			dstName = null;
 		}
-
-		writeSpace();
-		write(dstName);
-		writeLn();
-
-		dstName = null;
 
 		return targetKind == MappedElementKind.CLASS; // only members are supported, skip anything but class contents
 	}

--- a/src/main/java/net/fabricmc/mappingio/format/srg/JamFileWriter.java
+++ b/src/main/java/net/fabricmc/mappingio/format/srg/JamFileWriter.java
@@ -124,7 +124,9 @@ public final class JamFileWriter implements MappingWriter {
 		} else if (targetKind == MappedElementKind.FIELD
 				|| (isMethod = targetKind == MappedElementKind.METHOD)
 				|| (isArg = targetKind == MappedElementKind.METHOD_ARG)) {
-			if (classOnlyPass || memberSrcDesc == null || memberDstName == null) {
+			if (classOnlyPass) {
+				return false;
+			} else if (memberSrcDesc == null || (!isArg && memberDstName == null)) {
 				return isMethod;
 			}
 

--- a/src/test/java/net/fabricmc/mappingio/SubsetAssertingVisitor.java
+++ b/src/test/java/net/fabricmc/mappingio/SubsetAssertingVisitor.java
@@ -80,7 +80,7 @@ public class SubsetAssertingVisitor implements FlatMappingVisitor {
 
 		if (supCls == null) {
 			String[] tmpDst = supHasNamespaces ? dstNames : new String[]{dstNames[0]};
-			if (!Arrays.stream(tmpDst).anyMatch(Objects::nonNull)) return false;
+			if (!Arrays.stream(tmpDst).anyMatch(Objects::nonNull)) return true;
 			throw new RuntimeException("SubTree class not contained in SupTree: " + srcName);
 		}
 
@@ -111,7 +111,7 @@ public class SubsetAssertingVisitor implements FlatMappingVisitor {
 
 		if (supFld == null) {
 			String[] tmpDst = supHasNamespaces ? dstNames : new String[]{dstNames[0]};
-			if (!Arrays.stream(tmpDst).anyMatch(Objects::nonNull)) return false;
+			if (!Arrays.stream(tmpDst).anyMatch(Objects::nonNull)) return true;
 			throw new RuntimeException("SubTree field not contained in SupTree: " + srcName);
 		}
 
@@ -149,7 +149,7 @@ public class SubsetAssertingVisitor implements FlatMappingVisitor {
 
 		if (supMth == null) {
 			String[] tmpDst = supHasNamespaces ? dstNames : new String[]{dstNames[0]};
-			if (!Arrays.stream(tmpDst).anyMatch(Objects::nonNull)) return false;
+			if (!Arrays.stream(tmpDst).anyMatch(Objects::nonNull)) return true;
 			throw new RuntimeException("SubTree method not contained in SupTree: " + srcName);
 		}
 
@@ -187,7 +187,7 @@ public class SubsetAssertingVisitor implements FlatMappingVisitor {
 
 		if (supArg == null) {
 			String[] tmpDst = supHasNamespaces ? dstNames : new String[]{dstNames[0]};
-			if (!Arrays.stream(tmpDst).anyMatch(Objects::nonNull)) return false;
+			if (!Arrays.stream(tmpDst).anyMatch(Objects::nonNull)) return true;
 			throw new RuntimeException("SubTree arg not contained in SupTree: " + srcName);
 		}
 
@@ -221,7 +221,7 @@ public class SubsetAssertingVisitor implements FlatMappingVisitor {
 
 		if (supVar == null) {
 			String[] tmpDst = supHasNamespaces ? dstNames : new String[]{dstNames[0]};
-			if (!Arrays.stream(tmpDst).anyMatch(Objects::nonNull)) return false;
+			if (!Arrays.stream(tmpDst).anyMatch(Objects::nonNull)) return true;
 			throw new RuntimeException("SubTree var not contained in SupTree: " + srcName);
 		}
 

--- a/src/test/resources/read/valid-with-holes/jam.jam
+++ b/src/test/resources/read/valid-with-holes/jam.jam
@@ -8,3 +8,5 @@ FD class_32 field_2 I field2Ns0Rename
 FD class_32 field_5 I field5Ns0Rename
 MD class_32 method_2 ()I method2Ns0Rename
 MD class_32 method_5 ()I method5Ns0Rename
+MP class_32 method_7 ()I 4 param3Ns0Rename
+MP class_32 method_7 ()I 8 param5Ns0Rename


### PR DESCRIPTION
I haven't noticed this previously due to an oversight in `SubsetAssertingVisitor`. Only affects the CSRG and JAM writers, which both have just been added in 0.6, so we don't have to backport anything to 0.5.