### PR TITLE
Prevent instantiation of `VisitOrder` and `JobfFileReader`

### DIFF
--- a/src/main/java/net/fabricmc/mappingio/format/jobf/JobfFileReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/jobf/JobfFileReader.java
@@ -34,6 +34,9 @@ import net.fabricmc.mappingio.tree.MemoryMappingTree;
  * {@linkplain MappingFormat#JOBF_FILE JOBF file} reader.
  */
 public class JobfFileReader {
+	private JobfFileReader() {
+	}
+
 	public static void read(Reader reader, MappingVisitor visitor) throws IOException {
 		read(reader, MappingUtil.NS_SOURCE_FALLBACK, MappingUtil.NS_TARGET_FALLBACK, visitor);
 	}

--- a/src/main/java/net/fabricmc/mappingio/tree/VisitOrder.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/VisitOrder.java
@@ -35,6 +35,9 @@ import net.fabricmc.mappingio.tree.MappingTreeView.MethodVarMappingView;
  * Visitation order configuration for {@link MappingTreeView#accept(net.fabricmc.mappingio.MappingVisitor, VisitOrder)}.
  */
 public final class VisitOrder {
+	private VisitOrder() {
+	}
+
 	// pre-defined orders
 
 	public static VisitOrder createByInputOrder() {


### PR DESCRIPTION
Just like #38, for two classes that have been added since and didn't receive the same treatment.