### PR TITLE
Refer to TSRG version 2 as `TSRG v2` instead of `TSRG2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.0] - 2024-04-12
 - Added CSRG writer
-- Added TSRG and TSRG2 writer
+- Added TSRG and TSRG v2 writer
 - Added JAM reader and writer
 - Added JOBF reader and writer
 - Added Recaf Simple reader and writer
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed ProGuard writer producing invalid files when missing destination names
 - Fixed Enigma reader throwing incorrect error message
 - Fixed NPE in `MemoryMappingTree`
-- Fixed TSRG2 reader not handling multiple passes correctly
+- Fixed TSRG v2 reader not handling multiple passes correctly
 
 ## [0.5.0] - 2023-11-15
 - Actually marked `HierarchyInfoProvider` as experimental
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deferred existing Enigma directory deletion to writer visit pass start
 - Made `MappingWriter#create` return null instead of throwing an exception
 - Moved `MappingTreeRemapper`, `TinyRemapperHierarchyProvider` and `ClassAnalysisDescCompleter` to new `mapping-io-extras` publication
-- Fixed TSRG2 reporting itself as not supporting field descriptors
+- Fixed TSRG v2 reporting itself as not supporting field descriptors
 - Fixed regular <-> flat visitor adapter methods
 
 ## [0.5.0-beta.1] - 2023-10-09

--- a/src/main/java/net/fabricmc/mappingio/format/MappingFormat.java
+++ b/src/main/java/net/fabricmc/mappingio/format/MappingFormat.java
@@ -99,7 +99,7 @@ public enum MappingFormat {
 	 * <h2>Implementation notes</h2>
 	 * Package mappings and static markers for methods are currently not supported.
 	 */
-	TSRG_2_FILE("TSRG2 file", "tsrg", true, true, false, true, false, true),
+	TSRG_2_FILE("TSRG v2 file", "tsrg", true, true, false, true, false, true),
 
 	/**
 	 * ProGuard's mapping format, as specified <a href="https://www.guardsquare.com/manual/tools/retrace">here</a>.

--- a/src/main/java/net/fabricmc/mappingio/format/srg/TsrgFileReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/srg/TsrgFileReader.java
@@ -33,7 +33,7 @@ import net.fabricmc.mappingio.format.MappingFormat;
 /**
  * {@linkplain MappingFormat#CSRG_FILE CSRG file},
  * {@linkplain MappingFormat#TSRG_FILE TSRG file} and
- * {@linkplain MappingFormat#TSRG_2_FILE TSRG2 file} reader.
+ * {@linkplain MappingFormat#TSRG_2_FILE TSRG v2 file} reader.
  *
  * <p>Crashes if a second visit pass is requested without
  * {@link MappingFlag#NEEDS_MULTIPLE_PASSES} having been passed beforehand.

--- a/src/main/java/net/fabricmc/mappingio/format/srg/TsrgFileWriter.java
+++ b/src/main/java/net/fabricmc/mappingio/format/srg/TsrgFileWriter.java
@@ -32,7 +32,7 @@ import net.fabricmc.mappingio.format.MappingFormat;
 
 /**
  * {@linkplain MappingFormat#TSRG_FILE TSRG file} and
- * {@linkplain MappingFormat#TSRG_2_FILE TSRG2 file} writer.
+ * {@linkplain MappingFormat#TSRG_2_FILE TSRG v2 file} writer.
  */
 public final class TsrgFileWriter implements MappingWriter {
 	public TsrgFileWriter(Writer writer, boolean tsrg2) {


### PR DESCRIPTION
Seems to be the official name: https://github.com/MinecraftForge/SrgUtils/blob/67f30647ece29f18256ca89a23cda6216d6bd21e/src/main/java/net/minecraftforge/srgutils/InternalUtils.java#L306