### PR TITLE
Make `ColumnFileReader` consume trailing column separators instead of leading ones

### DIFF
--- a/src/test/java/net/fabricmc/mappingio/TestHelper.java
+++ b/src/test/java/net/fabricmc/mappingio/TestHelper.java
@@ -91,6 +91,7 @@ public final class TestHelper {
 		visitMethodArg(tree, dstNs);
 		visitMethodVar(tree, dstNs);
 		visitInnerClass(tree, 1, dstNs);
+		visitComment(tree);
 		visitField(tree, dstNs);
 		visitClass(tree, dstNs);
 

--- a/src/test/java/net/fabricmc/mappingio/read/ValidContentReadTest.java
+++ b/src/test/java/net/fabricmc/mappingio/read/ValidContentReadTest.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.mappingio.read;
 
+import java.nio.file.Path;
+
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -25,8 +27,10 @@ import net.fabricmc.mappingio.SubsetAssertingVisitor;
 import net.fabricmc.mappingio.TestHelper;
 import net.fabricmc.mappingio.VisitOrderVerifyingVisitor;
 import net.fabricmc.mappingio.adapter.FlatAsRegularMappingVisitor;
+import net.fabricmc.mappingio.adapter.MappingSourceNsSwitch;
 import net.fabricmc.mappingio.format.MappingFormat;
 import net.fabricmc.mappingio.tree.MappingTree;
+import net.fabricmc.mappingio.tree.MappingTreeView;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
 import net.fabricmc.mappingio.tree.VisitableMappingTree;
 
@@ -131,27 +135,38 @@ public class ValidContentReadTest {
 		checkHoles(format);
 	}
 
-	private VisitableMappingTree checkDefault(MappingFormat format) throws Exception {
+	private void checkDefault(MappingFormat format) throws Exception {
+		Path path = TestHelper.MappingDirs.VALID.resolve(TestHelper.getFileName(format));
+
 		VisitableMappingTree tree = new MemoryMappingTree();
-		MappingReader.read(TestHelper.MappingDirs.VALID.resolve(TestHelper.getFileName(format)), format, new VisitOrderVerifyingVisitor(tree));
+		MappingReader.read(path, format, new VisitOrderVerifyingVisitor(tree));
+		assertEqual(format, tree, testTree);
 
-		assertSubset(tree, format, testTree, null);
-		assertSubset(testTree, null, tree, format);
-
-		return tree;
+		tree = new MemoryMappingTree();
+		MappingReader.read(path, format,
+				new MappingSourceNsSwitch(
+						new VisitOrderVerifyingVisitor(
+								new MappingSourceNsSwitch(
+										new VisitOrderVerifyingVisitor(tree),
+										testTree.getSrcNamespace())),
+						testTree.getDstNamespaces().get(0)));
+		assertEqual(format, tree, testTree);
 	}
 
-	private VisitableMappingTree checkHoles(MappingFormat format) throws Exception {
+	private void checkHoles(MappingFormat format) throws Exception {
+		Path path = TestHelper.MappingDirs.VALID_WITH_HOLES.resolve(TestHelper.getFileName(format));
+
 		VisitableMappingTree tree = new MemoryMappingTree();
-		MappingReader.read(TestHelper.MappingDirs.VALID_WITH_HOLES.resolve(TestHelper.getFileName(format)), format, new VisitOrderVerifyingVisitor(tree));
-
-		assertSubset(tree, format, testTreeWithHoles, null);
-		assertSubset(testTreeWithHoles, null, tree, format);
-
-		return tree;
+		MappingReader.read(path, format, new VisitOrderVerifyingVisitor(tree));
+		assertEqual(format, tree, testTreeWithHoles);
 	}
 
-	private void assertSubset(MappingTree subTree, @Nullable MappingFormat subFormat, MappingTree supTree, @Nullable MappingFormat supFormat) throws Exception {
+	private void assertEqual(MappingFormat format, MappingTreeView tree, MappingTreeView referenceTree) throws Exception {
+		assertSubset(tree, format, referenceTree, null);
+		assertSubset(referenceTree, null, tree, format);
+	}
+
+	private void assertSubset(MappingTreeView subTree, @Nullable MappingFormat subFormat, MappingTreeView supTree, @Nullable MappingFormat supFormat) throws Exception {
 		subTree.accept(
 				new VisitOrderVerifyingVisitor(
 						new FlatAsRegularMappingVisitor(

--- a/src/test/resources/read/valid/enigma-dir/class1Ns0Rename.mapping
+++ b/src/test/resources/read/valid/enigma-dir/class1Ns0Rename.mapping
@@ -3,4 +3,5 @@ CLASS class_1 class1Ns0Rename
 	METHOD method_1 method1Ns0Rename ()I
 		ARG 1 param1Ns0Rename
 	CLASS class_2 class2Ns0Rename
+		COMMENT This is a comment
 		FIELD field_2 field2Ns0Rename I

--- a/src/test/resources/read/valid/enigma.mappings
+++ b/src/test/resources/read/valid/enigma.mappings
@@ -3,5 +3,6 @@ CLASS class_1 class1Ns0Rename
 	METHOD method_1 method1Ns0Rename ()I
 		ARG 1 param1Ns0Rename
 	CLASS class_2 class2Ns0Rename
+		COMMENT This is a comment
 		FIELD field_2 field2Ns0Rename I
 CLASS class_3 class3Ns0Rename

--- a/src/test/resources/read/valid/tinyV2.tiny
+++ b/src/test/resources/read/valid/tinyV2.tiny
@@ -5,5 +5,6 @@ c	class_1	class1Ns0Rename	class1Ns1Rename
 		p	1	param_1	param1Ns0Rename	param1Ns1Rename
 		v	2	2	2	var_1	var1Ns0Rename	var1Ns1Rename
 c	class_1$class_2	class1Ns0Rename$class2Ns0Rename	class1Ns1Rename$class2Ns1Rename
+	c	This is a comment
 	f	I	field_2	field2Ns0Rename	field2Ns1Rename
 c	class_3	class3Ns0Rename	class3Ns1Rename


### PR DESCRIPTION
This restores the pre-https://github.com/FabricMC/mapping-io/commit/36c52a537a06b812b8855c6d5cf176dd58c14540 behavior, fixing `\tc` (a comment) sometimes being interpreted as `c` (a class) in Tiny v2.