### PR TITLE
Fix migration maps not being readable by IntelliJ IDEA

### DIFF
--- a/src/main/java/net/fabricmc/mappingio/format/intellij/MigrationMapConstants.java
+++ b/src/main/java/net/fabricmc/mappingio/format/intellij/MigrationMapConstants.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.mappingio.format.intellij;
+
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+public final class MigrationMapConstants {
+	private MigrationMapConstants() {
+	}
+
+	public static final String ORDER_KEY = "migrationmap:order";
+	public static final String MISSING_NAME = "Unnamed migration map";
+}

--- a/src/main/java/net/fabricmc/mappingio/format/intellij/MigrationMapFileReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/intellij/MigrationMapFileReader.java
@@ -108,9 +108,15 @@ public final class MigrationMapFileReader {
 
 						switch (name) {
 						case "name":
+						case "order":
 						case "description":
 							if (visitHeader) {
-								// TODO: visit as metadata once https://github.com/FabricMC/mapping-io/pull/29 is merged
+								String value = xmlReader.getAttributeValue(null, "value");
+
+								if (name.equals("order")) name = MigrationMapConstants.ORDER_KEY;
+								if (name.equals("name") && value.equals(MigrationMapConstants.MISSING_NAME)) break;
+
+								visitor.visitMetadata(name, value);
 							}
 
 							break;

--- a/src/main/java/net/fabricmc/mappingio/format/tiny/Tiny2FileWriter.java
+++ b/src/main/java/net/fabricmc/mappingio/format/tiny/Tiny2FileWriter.java
@@ -29,6 +29,7 @@ import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingFlag;
 import net.fabricmc.mappingio.MappingWriter;
 import net.fabricmc.mappingio.format.MappingFormat;
+import net.fabricmc.mappingio.format.intellij.MigrationMapConstants;
 
 /**
  * {@linkplain MappingFormat#TINY_2_FILE Tiny v2 file} writer.
@@ -66,9 +67,13 @@ public final class Tiny2FileWriter implements MappingWriter {
 
 	@Override
 	public void visitMetadata(String key, @Nullable String value) throws IOException {
-		if (key.equals(Tiny2Util.escapedNamesProperty)) {
+		switch (key) {
+		case Tiny2Util.escapedNamesProperty:
 			escapeNames = true;
 			wroteEscapedNamesProperty = true;
+			break;
+		case MigrationMapConstants.ORDER_KEY:
+			return;
 		}
 
 		writeTab();

--- a/src/test/java/net/fabricmc/mappingio/TestHelper.java
+++ b/src/test/java/net/fabricmc/mappingio/TestHelper.java
@@ -29,6 +29,7 @@ import org.cadixdev.lorenz.io.MappingFormats;
 import org.jetbrains.annotations.Nullable;
 
 import net.fabricmc.mappingio.format.MappingFormat;
+import net.fabricmc.mappingio.format.intellij.MigrationMapConstants;
 import net.fabricmc.mappingio.tree.MappingTreeView;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
@@ -147,6 +148,8 @@ public final class TestHelper {
 	public static MemoryMappingTree createTestTree() {
 		MemoryMappingTree tree = new MemoryMappingTree();
 		tree.visitNamespaces(MappingUtil.NS_SOURCE_FALLBACK, Arrays.asList(MappingUtil.NS_TARGET_FALLBACK, MappingUtil.NS_TARGET_FALLBACK + "2"));
+		tree.visitMetadata("name", "valid");
+		tree.visitMetadata(MigrationMapConstants.ORDER_KEY, "0");
 		int[] dstNs = new int[] { 0, 1 };
 		nameGen.reset();
 

--- a/src/test/java/net/fabricmc/mappingio/tree/MetadataTest.java
+++ b/src/test/java/net/fabricmc/mappingio/tree/MetadataTest.java
@@ -43,6 +43,7 @@ public class MetadataTest {
 	@BeforeAll
 	public static void setup() throws Exception {
 		tree = TestHelper.createTestTree();
+		tree.getMetadata().clear();
 
 		for (int i = 0; i < 40; i++) {
 			String key = "key" + random.nextInt(3);

--- a/src/test/resources/read/repeated-elements/migration-map.xml
+++ b/src/test/resources/read/repeated-elements/migration-map.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <migrationMap>
-	<entry oldName="class_1" newName="class1Ns0Rename0" type="class" />
-	<entry oldName="class_1" newName="class1Ns0Rename" type="class" />
-	<entry oldName="class_1$class_2" newName="class1Ns0Rename$class2Ns0Rename0" type="class" />
-	<entry oldName="class_1$class_2" newName="class1Ns0Rename$class2Ns0Rename" type="class" />
-	<entry oldName="class_3" newName="class3Ns0Rename0" type="class" />
-	<entry oldName="class_3" newName="class3Ns0Rename" type="class" />
+	<name value="repeated-elements"/>
+	<order value="0"/>
+	<entry oldName="class_1" newName="class1Ns0Rename0" type="class"/>
+	<entry oldName="class_1" newName="class1Ns0Rename" type="class"/>
+	<entry oldName="class_1$class_2" newName="class1Ns0Rename$class2Ns0Rename0" type="class"/>
+	<entry oldName="class_1$class_2" newName="class1Ns0Rename$class2Ns0Rename" type="class"/>
+	<entry oldName="class_3" newName="class3Ns0Rename0" type="class"/>
+	<entry oldName="class_3" newName="class3Ns0Rename" type="class"/>
 </migrationMap>
-

--- a/src/test/resources/read/repeated-elements/tinyV2.tiny
+++ b/src/test/resources/read/repeated-elements/tinyV2.tiny
@@ -1,4 +1,5 @@
 tiny	2	0	source	target	target2
+	name	repeated-elements
 c	class_1	class1Ns0Rename0	class1Ns1Rename0
 c	class_1	class1Ns0Rename	class1Ns1Rename
 	f	I	field_1	field1Ns0Rename0	field1Ns1Rename0

--- a/src/test/resources/read/valid-with-holes/migration-map.xml
+++ b/src/test/resources/read/valid-with-holes/migration-map.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <migrationMap>
-	<entry oldName="class_2" newName="class2Ns0Rename" type="class" />
-	<entry oldName="class_5" newName="class5Ns0Rename" type="class" />
-	<entry oldName="class_7$class_8" newName="class_7$class8Ns0Rename" type="class" />
-	<entry oldName="class_13$class_14" newName="class_13$class14Ns0Rename" type="class" />
-	<entry oldName="class_17$class_18$class_19" newName="class_17$class_18$class19Ns0Rename" type="class" />
-	<entry oldName="class_26$class_27$class_28" newName="class_26$class_27$class28Ns0Rename" type="class" />
+	<entry oldName="class_2" newName="class2Ns0Rename" type="class"/>
+	<entry oldName="class_5" newName="class5Ns0Rename" type="class"/>
+	<entry oldName="class_7$class_8" newName="class_7$class8Ns0Rename" type="class"/>
+	<entry oldName="class_13$class_14" newName="class_13$class14Ns0Rename" type="class"/>
+	<entry oldName="class_17$class_18$class_19" newName="class_17$class_18$class19Ns0Rename" type="class"/>
+	<entry oldName="class_26$class_27$class_28" newName="class_26$class_27$class28Ns0Rename" type="class"/>
+	<name value="Unnamed migration map"/>
+	<order value="0"/>
 </migrationMap>

--- a/src/test/resources/read/valid/migration-map.xml
+++ b/src/test/resources/read/valid/migration-map.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <migrationMap>
-	<entry oldName="class_1" newName="class1Ns0Rename" type="class" />
-	<entry oldName="class_1$class_2" newName="class1Ns0Rename$class2Ns0Rename" type="class" />
-	<entry oldName="class_3" newName="class3Ns0Rename" type="class" />
+	<name value="valid"/>
+	<order value="0"/>
+	<entry oldName="class_1" newName="class1Ns0Rename" type="class"/>
+	<entry oldName="class_1$class_2" newName="class1Ns0Rename$class2Ns0Rename" type="class"/>
+	<entry oldName="class_3" newName="class3Ns0Rename" type="class"/>
 </migrationMap>
-

--- a/src/test/resources/read/valid/tinyV2.tiny
+++ b/src/test/resources/read/valid/tinyV2.tiny
@@ -1,4 +1,5 @@
 tiny	2	0	source	target	target2
+	name	valid
 c	class_1	class1Ns0Rename	class1Ns1Rename
 	f	I	field_1	field1Ns0Rename	field1Ns1Rename
 	m	()I	method_1	method1Ns0Rename	method1Ns1Rename


### PR DESCRIPTION
The `name` and `order` elements are required for IntelliJ IDEA to detect the file as an actual migration map. Some changes could be implemented more cleanly once #29 is merged, but this works for now.

Depends on #111.