### PR TITLE
Make `OuterClassNamePropagator` configurable, refactor tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Made `OuterClassNamePropagator` more configurable
+- Made `OuterClassNamePropagator` configurable
+- Added a simplified `MappingNsCompleter` constructor for completing all destination names with the source names
 
 ## [0.7.0] - 2025-01-01
 - Added IntelliJ IDEA migration map reader and writer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Made `OuterClassNamePropagator` more configurable
 
 ## [0.7.0] - 2025-01-01
 - Added IntelliJ IDEA migration map reader and writer

--- a/build.gradle
+++ b/build.gradle
@@ -201,13 +201,8 @@ jar {
 tasks.register("generateTestMappings", JavaExec) {
 	dependsOn("testClasses")
 	classpath = sourceSets.test.runtimeClasspath
-	mainClass = 'net.fabricmc.mappingio.TestFileUpdater'
-}
-
-tasks.register("updateTestMappings", Copy) {
-	dependsOn("generateTestMappings")
-	from 'build/resources/test/'
-	into 'src/test/resources/'
+	mainClass = 'net.fabricmc.mappingio.test.TestFileUpdater'
+	args = [file('src/test/resources/').getAbsolutePath()]
 }
 
 // A task to ensure that the version being released has not already been released.

--- a/mapping-io-extras/src/test/java/net/fabricmc/mappingio/extras/MappingTreeRemapperTest.java
+++ b/mapping-io-extras/src/test/java/net/fabricmc/mappingio/extras/MappingTreeRemapperTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Type;
 
-import net.fabricmc.mappingio.test.TestUtil;
+import net.fabricmc.mappingio.test.TestMappings;
 import net.fabricmc.mappingio.tree.MappingTree;
 import net.fabricmc.mappingio.tree.MappingTree.ClassMapping;
 import net.fabricmc.mappingio.tree.MappingTree.FieldMapping;
@@ -50,7 +50,7 @@ public class MappingTreeRemapperTest {
 
 	@BeforeAll
 	public static void setup() throws IOException {
-		mappingTree = TestUtil.acceptTestMappings(new MemoryMappingTree());
+		mappingTree = TestMappings.generateValid(new MemoryMappingTree());
 		srcNs = mappingTree.getSrcNamespace();
 		dstNs = mappingTree.getDstNamespaces().get(0);
 

--- a/src/main/java/net/fabricmc/mappingio/adapter/MappingNsCompleter.java
+++ b/src/main/java/net/fabricmc/mappingio/adapter/MappingNsCompleter.java
@@ -19,6 +19,7 @@ package net.fabricmc.mappingio.adapter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -35,8 +36,18 @@ import net.fabricmc.mappingio.MappingVisitor;
  */
 public final class MappingNsCompleter extends ForwardingMappingVisitor {
 	/**
+	 * Constructs a new {@link MappingNsCompleter} which completes all destination namespaces.
+	 *
+	 * @param next The next visitor to forward the data to.
+	 */
+	public MappingNsCompleter(MappingVisitor next) {
+		this(next, null, false);
+	}
+
+	/**
 	 * @param next The next visitor to forward the data to.
 	 * @param alternatives A map of which namespaces should copy from which others.
+	 * You can pass {@code null} if all destination namespaces shall be completed.
 	 */
 	public MappingNsCompleter(MappingVisitor next, Map<String, String> alternatives) {
 		this(next, alternatives, false);
@@ -45,6 +56,7 @@ public final class MappingNsCompleter extends ForwardingMappingVisitor {
 	/**
 	 * @param next The next visitor to forward the data to.
 	 * @param alternatives A map of which namespaces should copy from which others.
+	 * You can pass {@code null} if all destination namespaces shall be completed.
 	 * @param addMissingNs Whether to copy namespaces from the alternatives key set if not already present.
 	 */
 	public MappingNsCompleter(MappingVisitor next, Map<String, String> alternatives, boolean addMissingNs) {
@@ -63,6 +75,14 @@ public final class MappingNsCompleter extends ForwardingMappingVisitor {
 
 	@Override
 	public void visitNamespaces(String srcNamespace, List<String> dstNamespaces) throws IOException {
+		if (alternatives == null) {
+			alternatives = new HashMap<>(dstNamespaces.size());
+
+			for (String ns : dstNamespaces) {
+				alternatives.put(ns, srcNamespace);
+			}
+		}
+
 		if (addMissingNs) {
 			boolean copied = false;
 
@@ -192,8 +212,8 @@ public final class MappingNsCompleter extends ForwardingMappingVisitor {
 		return next.visitElementContent(targetKind);
 	}
 
-	private final Map<String, String> alternatives;
 	private final boolean addMissingNs;
+	private Map<String, String> alternatives;
 	private int[] alternativesMapping;
 
 	private String srcName;

--- a/src/main/java/net/fabricmc/mappingio/adapter/MappingNsCompleter.java
+++ b/src/main/java/net/fabricmc/mappingio/adapter/MappingNsCompleter.java
@@ -47,7 +47,7 @@ public final class MappingNsCompleter extends ForwardingMappingVisitor {
 	/**
 	 * @param next The next visitor to forward the data to.
 	 * @param alternatives A map of which namespaces should copy from which others.
-	 * You can pass {@code null} if all destination namespaces shall be completed.
+	 * Passing {@code null} causes all destination namespaces to be completed.
 	 */
 	public MappingNsCompleter(MappingVisitor next, Map<String, String> alternatives) {
 		this(next, alternatives, false);
@@ -56,7 +56,7 @@ public final class MappingNsCompleter extends ForwardingMappingVisitor {
 	/**
 	 * @param next The next visitor to forward the data to.
 	 * @param alternatives A map of which namespaces should copy from which others.
-	 * You can pass {@code null} if all destination namespaces shall be completed.
+	 * Passing {@code null} causes all destination namespaces to be completed.
 	 * @param addMissingNs Whether to copy namespaces from the alternatives key set if not already present.
 	 */
 	public MappingNsCompleter(MappingVisitor next, Map<String, String> alternatives, boolean addMissingNs) {

--- a/src/main/java/net/fabricmc/mappingio/adapter/MappingNsCompleter.java
+++ b/src/main/java/net/fabricmc/mappingio/adapter/MappingNsCompleter.java
@@ -49,7 +49,7 @@ public final class MappingNsCompleter extends ForwardingMappingVisitor {
 	 * @param alternatives A map of which namespaces should copy from which others.
 	 * Passing {@code null} causes all destination namespaces to be completed.
 	 */
-	public MappingNsCompleter(MappingVisitor next, Map<String, String> alternatives) {
+	public MappingNsCompleter(MappingVisitor next, @Nullable Map<String, String> alternatives) {
 		this(next, alternatives, false);
 	}
 
@@ -59,7 +59,7 @@ public final class MappingNsCompleter extends ForwardingMappingVisitor {
 	 * Passing {@code null} causes all destination namespaces to be completed.
 	 * @param addMissingNs Whether to copy namespaces from the alternatives key set if not already present.
 	 */
-	public MappingNsCompleter(MappingVisitor next, Map<String, String> alternatives, boolean addMissingNs) {
+	public MappingNsCompleter(MappingVisitor next, @Nullable Map<String, String> alternatives, boolean addMissingNs) {
 		super(next);
 
 		this.alternatives = alternatives;

--- a/src/main/java/net/fabricmc/mappingio/adapter/OuterClassNamePropagator.java
+++ b/src/main/java/net/fabricmc/mappingio/adapter/OuterClassNamePropagator.java
@@ -37,8 +37,8 @@ import net.fabricmc.mappingio.MappingVisitor;
 
 /**
  * Searches for inner classes whose effective destination name contains outer classes referenced via their source name,
- * waits for mappings for these enclosing classes, and applies the latter's destination names
- * to the former's fully qualified name.
+ * waits for mappings for these enclosing classes, and applies the latters' destination names
+ * to the formers' fully qualified name.
  *
  * <p>For example, it takes a class {@code class_1$class_2} that doesn't have a mapping,
  * tries to find {@code class_1}, which let's say has the mapping {@code SomeClass},
@@ -57,7 +57,7 @@ public class OuterClassNamePropagator extends ForwardingMappingVisitor {
 	}
 
 	/**
-	 * @param namespaces The destination namespaces where outer class names shall be propagated (isolated from each other).
+	 * @param namespaces The destination namespaces where outer class names shall be propagated.
 	 * @param processRemappedDstNames Whether already remapped destination names should also get their unmapped outer classes replaced.
 	 */
 	public OuterClassNamePropagator(MappingVisitor next, Collection<String> namespaces, boolean processRemappedDstNames) {
@@ -91,12 +91,12 @@ public class OuterClassNamePropagator extends ForwardingMappingVisitor {
 			} else {
 				if (dstNamespacesToProcess.contains(srcNamespace)) {
 					throw new UnsupportedOperationException(srcNamespace + " was passed as a destination namespace"
-							+ " to propagate outer class names to, but has been visited as the source namespace.");
+							+ " to propagate outer class names in, but has been visited as the source namespace.");
 				}
 
 				for (String ns : dstNamespacesToProcess) {
 					if (!dstNamespaces.contains(ns)) {
-						throw new IllegalArgumentException(ns + " was passed as a destination namespace to propagate outer class names to,"
+						throw new IllegalArgumentException(ns + " was passed as a destination namespace to propagate outer class names in,"
 								+ " but is not present in the namespaces of the current visitation pass.");
 					}
 				}
@@ -210,7 +210,7 @@ public class OuterClassNamePropagator extends ForwardingMappingVisitor {
 						String outerSrcName = String.join("$", Arrays.copyOfRange(srcParts, 0, pos + 1));
 
 						if (dstName != null && !dstParts[pos].equals(srcParts[pos])) {
-							// That part already has a differing mapping
+							// That part already has a different mapping
 							continue;
 						}
 

--- a/src/main/java/net/fabricmc/mappingio/adapter/OuterClassNamePropagator.java
+++ b/src/main/java/net/fabricmc/mappingio/adapter/OuterClassNamePropagator.java
@@ -57,10 +57,12 @@ public class OuterClassNamePropagator extends ForwardingMappingVisitor {
 	}
 
 	/**
-	 * @param namespaces The destination namespaces where outer class names shall be propagated.
+	 * Constructs a new {@link OuterClassNamePropagator} which processes the selected destination namespaces.
+	 *
+	 * @param namespaces The destination namespaces where outer class names shall be propagated. Pass {@code null} to process all destination namespaces.
 	 * @param processRemappedDstNames Whether already remapped destination names should also get their unmapped outer classes replaced.
 	 */
-	public OuterClassNamePropagator(MappingVisitor next, Collection<String> namespaces, boolean processRemappedDstNames) {
+	public OuterClassNamePropagator(MappingVisitor next, @Nullable Collection<String> namespaces, boolean processRemappedDstNames) {
 		super(next);
 		this.dstNamespacesToProcess = namespaces;
 		this.processRemappedDstNames = processRemappedDstNames;
@@ -257,6 +259,8 @@ public class OuterClassNamePropagator extends ForwardingMappingVisitor {
 	private final boolean processRemappedDstNames;
 	private final Map<String, String[]> dstNamesBySrcName = new HashMap<>();
 	private final Set<String> modifiedClasses = new HashSet<>();
+	private String srcNamespaceToProcess;
+	private int srcNsId;
 	private List<String> dstNamespaces;
 	private Collection<String> dstNamespacesToProcess;
 	private Collection<Integer> dstNamespaceIndicesToProcess;

--- a/src/main/java/net/fabricmc/mappingio/format/MappingFormat.java
+++ b/src/main/java/net/fabricmc/mappingio/format/MappingFormat.java
@@ -115,6 +115,27 @@ public enum MappingFormat {
 	ENIGMA_DIR("Enigma directory", null, true, FeatureSetBuilder.createFrom(ENIGMA_FILE.features)),
 
 	/**
+	 * ProGuard's mapping format, as specified <a href="https://www.guardsquare.com/manual/tools/retrace">here</a>.
+	 *
+	 * @implNote Line numbers are currently not supported.
+	 */
+	PROGUARD_FILE("ProGuard file", "txt", true, FeatureSetBuilder.create()
+			.withElementMetadata(MetadataSupport.FIXED) // line numbers
+			.withClasses(c -> c
+					.withSrcNames(FeaturePresence.REQUIRED)
+					.withDstNames(FeaturePresence.REQUIRED)
+					.withRepackaging(true))
+			.withFields(f -> f
+					.withSrcNames(FeaturePresence.REQUIRED)
+					.withDstNames(FeaturePresence.REQUIRED)
+					.withSrcDescs(FeaturePresence.REQUIRED))
+			.withMethods(m -> m
+					.withSrcNames(FeaturePresence.REQUIRED)
+					.withDstNames(FeaturePresence.REQUIRED)
+					.withSrcDescs(FeaturePresence.REQUIRED))
+			.withFileComments(true)),
+
+	/**
 	 * The {@code SRG} ("Searge RetroGuard") mapping format, as specified <a href="https://github.com/MinecraftForge/SrgUtils/blob/67f30647ece29f18256ca89a23cda6216d6bd21e/src/main/java/net/minecraftforge/srgutils/InternalUtils.java#L69-L81">here</a>.
 	 *
 	 * @implNote Package mappings are currently not supported.
@@ -197,27 +218,6 @@ public enum MappingFormat {
 					.withLvIndices(FeaturePresence.REQUIRED)
 					.withSrcNames(FeaturePresence.REQUIRED)
 					.withDstNames(FeaturePresence.REQUIRED))),
-
-	/**
-	 * ProGuard's mapping format, as specified <a href="https://www.guardsquare.com/manual/tools/retrace">here</a>.
-	 *
-	 * @implNote Line numbers are currently not supported.
-	 */
-	PROGUARD_FILE("ProGuard file", "txt", true, FeatureSetBuilder.create()
-			.withElementMetadata(MetadataSupport.FIXED) // line numbers
-			.withClasses(c -> c
-					.withSrcNames(FeaturePresence.REQUIRED)
-					.withDstNames(FeaturePresence.REQUIRED)
-					.withRepackaging(true))
-			.withFields(f -> f
-					.withSrcNames(FeaturePresence.REQUIRED)
-					.withDstNames(FeaturePresence.REQUIRED)
-					.withSrcDescs(FeaturePresence.REQUIRED))
-			.withMethods(m -> m
-					.withSrcNames(FeaturePresence.REQUIRED)
-					.withDstNames(FeaturePresence.REQUIRED)
-					.withSrcDescs(FeaturePresence.REQUIRED))
-			.withFileComments(true)),
 
 	/**
 	 * The IntelliJ IDEA migration map format, as implemented <a href="https://github.com/JetBrains/intellij-community/tree/5b6191dd34e05de8897f5da68757146395a260cc/java/java-impl-refactorings/src/com/intellij/refactoring/migration">here</a>.

--- a/src/test/java/net/fabricmc/mappingio/test/TestMappings.java
+++ b/src/test/java/net/fabricmc/mappingio/test/TestMappings.java
@@ -1,0 +1,460 @@
+/*
+ * Copyright (c) 2025 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.mappingio.test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.fabricmc.mappingio.MappedElementKind;
+import net.fabricmc.mappingio.MappingReader;
+import net.fabricmc.mappingio.MappingUtil;
+import net.fabricmc.mappingio.MappingVisitor;
+import net.fabricmc.mappingio.adapter.ForwardingMappingVisitor;
+import net.fabricmc.mappingio.adapter.OuterClassNamePropagator;
+import net.fabricmc.mappingio.format.MappingFormat;
+import net.fabricmc.mappingio.format.intellij.MigrationMapConstants;
+import net.fabricmc.mappingio.test.lib.jool.Unchecked;
+import net.fabricmc.mappingio.test.visitors.NopMappingVisitor;
+import net.fabricmc.mappingio.test.visitors.VisitOrderVerifyingVisitor;
+
+public class TestMappings {
+	public static <T extends MappingVisitor> T generateValid(T target) throws IOException {
+		MappingVisitor delegate = target instanceof VisitOrderVerifyingVisitor ? target : new VisitOrderVerifyingVisitor(target);
+
+		if (delegate.visitHeader()) {
+			delegate.visitNamespaces(MappingUtil.NS_SOURCE_FALLBACK, Arrays.asList(MappingUtil.NS_TARGET_FALLBACK, MappingUtil.NS_TARGET_FALLBACK + "2"));
+			delegate.visitMetadata("name", "valid");
+			delegate.visitMetadata(MigrationMapConstants.ORDER_KEY, "0");
+		}
+
+		if (delegate.visitContent()) {
+			int[] dstNs = new int[] { 0, 1 };
+			NameGen nameGen = new NameGen();
+
+			if (nameGen.visitClass(delegate, dstNs)) {
+				nameGen.visitField(delegate, dstNs);
+
+				if (nameGen.visitMethod(delegate, dstNs)) {
+					nameGen.visitMethodArg(delegate, dstNs);
+					nameGen.visitMethodVar(delegate, dstNs);
+				}
+			}
+
+			if (nameGen.visitInnerClass(delegate, 1, dstNs)) {
+				nameGen.visitComment(delegate);
+				nameGen.visitField(delegate, dstNs);
+			}
+
+			nameGen.visitClass(delegate, dstNs);
+		}
+
+		if (!delegate.visitEnd()) {
+			generateValid(delegate);
+		}
+
+		return target;
+	}
+
+	public static <T extends MappingVisitor> T generateRepeatedElements(T target, boolean repeatComments, boolean repeatClasses) throws IOException {
+		generateValid(new ForwardingMappingVisitor(new VisitOrderVerifyingVisitor(target, true)) {
+			private final List<Runnable> replayQueue = new ArrayList<>();
+
+			@Override
+			public void visitMetadata(String key, @Nullable String value) throws IOException {
+				super.visitMetadata(key, key.equals("name") ? "repeated-elements" : value);
+			}
+
+			@Override
+			public boolean visitClass(String srcName) throws IOException {
+				replayQueue.clear();
+
+				if (repeatClasses) {
+					replayQueue.add(Unchecked.runnable(() -> super.visitClass(srcName)));
+				}
+
+				return super.visitClass(srcName);
+			}
+
+			@Override
+			public boolean visitField(String srcName, @Nullable String srcDesc) throws IOException {
+				replayQueue.clear();
+				replayQueue.add(Unchecked.runnable(() -> super.visitField(srcName, srcDesc)));
+				return super.visitField(srcName, srcDesc);
+			}
+
+			@Override
+			public boolean visitMethod(String srcName, @Nullable String srcDesc) throws IOException {
+				replayQueue.clear();
+				replayQueue.add(Unchecked.runnable(() -> super.visitMethod(srcName, srcDesc)));
+				return super.visitMethod(srcName, srcDesc);
+			}
+
+			@Override
+			public boolean visitMethodArg(int lvIndex, int argIndex, String srcName) throws IOException {
+				replayQueue.clear();
+				replayQueue.add(Unchecked.runnable(() -> super.visitMethodArg(lvIndex, argIndex, srcName)));
+				return super.visitMethodArg(lvIndex, argIndex, srcName);
+			}
+
+			@Override
+			public boolean visitMethodVar(int lvIndex, int varIndex, int startOpIdx, int endOpIdx, String srcName) throws IOException {
+				replayQueue.clear();
+				replayQueue.add(Unchecked.runnable(() -> super.visitMethodVar(lvIndex, varIndex, startOpIdx, endOpIdx, srcName)));
+				return super.visitMethodVar(lvIndex, varIndex, startOpIdx, endOpIdx, srcName);
+			}
+
+			@Override
+			public void visitDstName(MappedElementKind targetKind, int namespace, String name) throws IOException {
+				if (targetKind == MappedElementKind.CLASS && !repeatClasses) {
+					super.visitDstName(targetKind, namespace, name);
+				} else {
+					replayQueue.add(Unchecked.runnable(() -> super.visitDstName(targetKind, namespace, name)));
+					super.visitDstName(targetKind, namespace, name + "0");
+				}
+			}
+
+			@Override
+			public void visitDstDesc(MappedElementKind targetKind, int namespace, String desc) throws IOException {
+				replayQueue.add(Unchecked.runnable(() -> super.visitDstDesc(targetKind, namespace, desc)));
+				super.visitDstDesc(targetKind, namespace, desc);
+			}
+
+			@Override
+			public boolean visitElementContent(MappedElementKind targetKind) throws IOException {
+				boolean ret = super.visitElementContent(targetKind);
+
+				if (!replayQueue.isEmpty()) {
+					replayQueue.forEach(Runnable::run);
+
+					ret = super.visitElementContent(targetKind);
+				}
+
+				return ret;
+			}
+
+			@Override
+			public void visitComment(MappedElementKind targetKind, String comment) throws IOException {
+				if (repeatComments) {
+					super.visitComment(targetKind, comment + ".");
+				}
+
+				super.visitComment(targetKind, comment);
+			}
+		});
+
+		return target;
+	}
+
+	public static <T extends MappingVisitor> T generateHoles(T target) throws IOException {
+		MappingVisitor delegate = target instanceof VisitOrderVerifyingVisitor ? target : new VisitOrderVerifyingVisitor(target);
+
+		if (delegate.visitHeader()) {
+			delegate.visitNamespaces(MappingUtil.NS_SOURCE_FALLBACK, Arrays.asList(MappingUtil.NS_TARGET_FALLBACK, MappingUtil.NS_TARGET_FALLBACK + "2"));
+		}
+
+		if (delegate.visitContent()) {
+			NameGen nameGen = new NameGen();
+
+			// (Inner) Classes
+			for (int nestLevel = 0; nestLevel <= 2; nestLevel++) {
+				nameGen.visitClass(delegate);
+				nameGen.visitClass(delegate);
+				nameGen.visitInnerClass(delegate, nestLevel, 0);
+				nameGen.visitInnerClass(delegate, nestLevel, 1);
+
+				if (nameGen.visitInnerClass(delegate, nestLevel)) {
+					nameGen.visitComment(delegate);
+				}
+
+				if (nameGen.visitInnerClass(delegate, nestLevel, 0)) {
+					nameGen.visitComment(delegate);
+				}
+
+				if (nameGen.visitInnerClass(delegate, nestLevel, 1)) {
+					nameGen.visitComment(delegate);
+				}
+			}
+
+			if (nameGen.visitClass(delegate)) {
+				// Fields
+				nameGen.visitField(delegate);
+				nameGen.visitField(delegate, 0);
+				nameGen.visitField(delegate, 1);
+
+				if (nameGen.visitField(delegate)) {
+					nameGen.visitComment(delegate);
+				}
+
+				if (nameGen.visitField(delegate, 0)) {
+					nameGen.visitComment(delegate);
+				}
+
+				if (nameGen.visitField(delegate, 1)) {
+					nameGen.visitComment(delegate);
+				}
+
+				// Methods
+				nameGen.visitMethod(delegate);
+				nameGen.visitMethod(delegate, 0);
+				nameGen.visitMethod(delegate, 1);
+
+				if (nameGen.visitMethod(delegate)) {
+					nameGen.visitComment(delegate);
+				}
+
+				if (nameGen.visitMethod(delegate, 0)) {
+					nameGen.visitComment(delegate);
+				}
+
+				if (nameGen.visitMethod(delegate, 1)) {
+					nameGen.visitComment(delegate);
+				}
+
+				// Method args
+				if (nameGen.visitMethod(delegate)) {
+					nameGen.visitMethodArg(delegate);
+					nameGen.visitMethodArg(delegate, 1);
+					nameGen.visitMethodArg(delegate, 0);
+
+					if (nameGen.visitMethodArg(delegate)) {
+						nameGen.visitComment(delegate);
+					}
+
+					if (nameGen.visitMethodArg(delegate, 0)) {
+						nameGen.visitComment(delegate);
+					}
+
+					if (nameGen.visitMethodArg(delegate, 1)) {
+						nameGen.visitComment(delegate);
+					}
+				}
+
+				// Method vars
+				if (nameGen.visitMethod(delegate)) {
+					nameGen.visitMethodVar(delegate);
+					nameGen.visitMethodVar(delegate, 1);
+					nameGen.visitMethodVar(delegate, 0);
+
+					if (nameGen.visitMethodVar(delegate)) {
+						nameGen.visitComment(delegate);
+					}
+
+					if (nameGen.visitMethodVar(delegate, 0)) {
+						nameGen.visitComment(delegate);
+					}
+
+					if (nameGen.visitMethodVar(delegate, 1)) {
+						nameGen.visitComment(delegate);
+					}
+				}
+			}
+		}
+
+		if (!delegate.visitEnd()) {
+			generateHoles(delegate);
+		}
+
+		return target;
+	}
+
+	public static <T extends MappingVisitor> T generateOuterClassNamePropagation(T target) throws IOException {
+		MappingVisitor delegate = target instanceof VisitOrderVerifyingVisitor ? target : new VisitOrderVerifyingVisitor(target);
+		String srcNs = MappingUtil.NS_SOURCE_FALLBACK;
+		List<String> dstNamespaces = Arrays.asList("dstNs0", "dstNs1", "dstNs2", "dstNs3", "dstNs4", "dstNs5", "dstNs6");
+
+		if (delegate.visitHeader()) {
+			delegate.visitNamespaces(srcNs, dstNamespaces);
+		}
+
+		if (delegate.visitContent()) {
+			if (delegate.visitClass("class_1")) {
+				delegate.visitDstName(MappedElementKind.CLASS, 0, "class1Ns0Rename");
+				delegate.visitDstName(MappedElementKind.CLASS, 1, "class1Ns1Rename");
+				delegate.visitDstName(MappedElementKind.CLASS, 2, "class1Ns2Rename");
+				delegate.visitDstName(MappedElementKind.CLASS, 4, "class1Ns4Rename");
+
+				if (delegate.visitElementContent(MappedElementKind.CLASS)) {
+					if (delegate.visitField("field_1", "Lclass_1;")) {
+						for (int i = 0; i <= 6; i++) {
+							delegate.visitDstDesc(MappedElementKind.FIELD, i, "Lclass_1;");
+						}
+
+						delegate.visitElementContent(MappedElementKind.FIELD);
+					}
+				}
+			}
+
+			if (delegate.visitClass("class_1$class_2")) {
+				delegate.visitDstName(MappedElementKind.CLASS, 2, "class1Ns2Rename$class2Ns2Rename");
+				delegate.visitDstName(MappedElementKind.CLASS, 3, "class_1$class2Ns3Rename");
+				delegate.visitDstName(MappedElementKind.CLASS, 4, "class_1$class_2");
+				delegate.visitDstName(MappedElementKind.CLASS, 5, "class_1$class2Ns5Rename");
+
+				if (delegate.visitElementContent(MappedElementKind.CLASS)) {
+					if (delegate.visitField("field_2", "Lclass_1$class_2;")) {
+						for (int i = 0; i <= 6; i++) {
+							delegate.visitDstDesc(MappedElementKind.FIELD, i, "Lclass_1$class_2;");
+						}
+
+						delegate.visitElementContent(MappedElementKind.FIELD);
+					}
+				}
+			}
+
+			if (delegate.visitClass("class_1$class_2$class_3")) {
+				delegate.visitDstName(MappedElementKind.CLASS, 5, "class_1$class_2$class3Ns5Rename");
+				delegate.visitDstName(MappedElementKind.CLASS, 6, "class_1$class_2$class3Ns6Rename");
+
+				if (delegate.visitElementContent(MappedElementKind.CLASS)) {
+					if (delegate.visitField("field_2", "Lclass_1$class_2$class_3;")) {
+						for (int i = 0; i <= 6; i++) {
+							delegate.visitDstDesc(MappedElementKind.FIELD, i, "Lclass_1$class_2$class_3;");
+						}
+
+						delegate.visitElementContent(MappedElementKind.FIELD);
+					}
+				}
+			}
+		}
+
+		if (!delegate.visitEnd()) {
+			generateOuterClassNamePropagation(delegate);
+		}
+
+		return target;
+	}
+
+	private static MappingDir register(MappingDir dir) {
+		dirs.add(dir);
+		dirsByPath.put(dir.path, dir);
+		return dir;
+	}
+
+	public static Set<MappingDir> values() {
+		return Collections.unmodifiableSet(dirs);
+	}
+
+	private static final Set<MappingDir> dirs = new HashSet<>();
+	private static final Map<Path, MappingDir> dirsByPath = new HashMap<>();
+
+	public static final MappingDir DETECTION = register(new MappingDir(TestUtil.getResource("/detection/")) {
+		public <T extends MappingVisitor> T generate(T target) throws IOException {
+			throw new UnsupportedOperationException();
+		};
+	});
+	public static final Path MERGING = TestUtil.getResource("/merging/");
+
+	public static class READING {
+		public static final Path BASE_DIR = TestUtil.getResource("/reading/");
+
+		public static final MappingDir VALID = register(new MappingDir(BASE_DIR.resolve("valid/")) {
+			public <T extends MappingVisitor> T generate(T target) throws IOException {
+				return generateValid(target);
+			};
+		});
+		public static final MappingDir HOLES = register(new MappingDir(BASE_DIR.resolve("holes/")) {
+			public <T extends MappingVisitor> T generate(T target) throws IOException {
+				return generateHoles(target);
+			};
+		});
+		public static final MappingDir REPEATED_ELEMENTS = register(new MappingDir(BASE_DIR.resolve("repeated-elements/")) {
+			public <T extends MappingVisitor> T generate(T target) throws IOException {
+				return generateRepeatedElements(target, true, true);
+			};
+		});
+	}
+
+	public static class PROPAGATION {
+		public static final Path BASE_DIR = TestUtil.getResource("/outer-class-name-propagation/");
+
+		public static final MappingDir UNPROPAGATED = register(new MappingDir(BASE_DIR.resolve("unpropagated/")) {
+			public <T extends MappingVisitor> T generate(T target) throws IOException {
+				return generateOuterClassNamePropagation(target);
+			};
+		});
+		public static final MappingDir PROPAGATED = register(new MappingDir(BASE_DIR.resolve("propagated/")) {
+			public <T extends MappingVisitor> T generate(T target) throws IOException {
+				generateOuterClassNamePropagation(new OuterClassNamePropagator(target));
+				return target;
+			};
+		});
+		public static final MappingDir PROPAGATED_EXCEPT_REMAPPED_DST = register(new MappingDir(BASE_DIR.resolve("propagated-except-remapped-dst/")) {
+			public <T extends MappingVisitor> T generate(T target) throws IOException {
+				generateOuterClassNamePropagation(new OuterClassNamePropagator(target, null, false));
+				return target;
+			};
+		});
+	}
+
+	static {
+		// Force-load classes to ensure all MappingDirs are registered
+		READING.BASE_DIR.toString();
+		PROPAGATION.BASE_DIR.toString();
+	}
+
+	public abstract static class MappingDir {
+		private final Path path;
+		private boolean supportsGeneration;
+
+		private MappingDir(Path path) {
+			this.path = path;
+
+			try {
+				generate(new NopMappingVisitor(false));
+				supportsGeneration = true;
+			} catch (UnsupportedOperationException e) {
+				supportsGeneration = false;
+			} catch (IOException e) {
+				throw new UncheckedIOException(e);
+			}
+		}
+
+		public Path path() {
+			return path;
+		}
+
+		public Path pathFor(MappingFormat format) {
+			return path.resolve(TestUtil.getFileName(format));
+		}
+
+		public boolean isIn(Path path) {
+			return this.path.startsWith(path);
+		}
+
+		public <T extends MappingVisitor> T read(MappingFormat format, T target) throws IOException {
+			MappingReader.read(pathFor(format), format, target);
+			return target;
+		}
+
+		public boolean supportsGeneration() {
+			return supportsGeneration;
+		}
+
+		public abstract <T extends MappingVisitor> T generate(T target) throws IOException;
+	}
+}

--- a/src/test/java/net/fabricmc/mappingio/test/TestMappings.java
+++ b/src/test/java/net/fabricmc/mappingio/test/TestMappings.java
@@ -42,6 +42,12 @@ import net.fabricmc.mappingio.test.lib.jool.Unchecked;
 import net.fabricmc.mappingio.test.visitors.NopMappingVisitor;
 import net.fabricmc.mappingio.test.visitors.VisitOrderVerifyingVisitor;
 
+/*
+ * After any changes to the "generate" methods, run the "generateTestMappings" Gradle task
+ * to update the mapping files located in the resources folder accordingly.
+ *
+ * Make sure to keep the manual Enigma and SRG changes in the "repeated-elements" directory.
+ */
 public class TestMappings {
 	public static <T extends MappingVisitor> T generateValid(T target) throws IOException {
 		MappingVisitor delegate = target instanceof VisitOrderVerifyingVisitor ? target : new VisitOrderVerifyingVisitor(target);

--- a/src/test/java/net/fabricmc/mappingio/test/TestUtil.java
+++ b/src/test/java/net/fabricmc/mappingio/test/TestUtil.java
@@ -18,32 +18,42 @@ package net.fabricmc.mappingio.test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 import net.neoforged.srgutils.IMappingFile;
 import org.cadixdev.lorenz.io.MappingFormats;
 import org.jetbrains.annotations.Nullable;
 
-import net.fabricmc.mappingio.MappedElementKind;
-import net.fabricmc.mappingio.MappingUtil;
-import net.fabricmc.mappingio.MappingVisitor;
 import net.fabricmc.mappingio.MappingWriter;
-import net.fabricmc.mappingio.adapter.ForwardingMappingVisitor;
 import net.fabricmc.mappingio.format.MappingFormat;
-import net.fabricmc.mappingio.format.intellij.MigrationMapConstants;
-import net.fabricmc.mappingio.test.lib.jool.Unchecked;
-import net.fabricmc.mappingio.test.visitors.VisitOrderVerifyingVisitor;
 import net.fabricmc.mappingio.tree.MappingTreeView;
-import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
+/*
+ * After any changes to the "accept" methods, run the "generateTestMappings" Gradle task
+ * to update the mapping files located in the resources folder accordingly.
+ *
+ * Make sure to keep the manual Enigma and SRG changes in the "repeated-elements" directory.
+ */
 public final class TestUtil {
+	public static void setResourceRoot(Path path) {
+		resourceRoot = path;
+	}
+
 	public static Path getResource(String slashPrefixedResourcePath) {
+		if (resourceRoot != null) {
+			return resourceRoot.resolve(slashPrefixedResourcePath.substring(1));
+		}
+
 		try {
-			return Paths.get(TestUtil.class.getResource(slashPrefixedResourcePath).toURI());
+			URL url = TestUtil.class.getResource(slashPrefixedResourcePath);
+
+			if (url == null) {
+				throw new IllegalArgumentException("Resource not found: " + slashPrefixedResourcePath);
+			}
+
+			return Paths.get(url.toURI());
 		} catch (URISyntaxException e) {
 			throw new RuntimeException(e);
 		}
@@ -151,262 +161,5 @@ public final class TestUtil {
 		return path;
 	}
 
-	// After any changes, run "./gradlew updateTestMappings" to update the mapping files in the resources folder accordingly
-	public static <T extends MappingVisitor> T acceptTestMappings(T target) throws IOException {
-		MappingVisitor delegate = target instanceof VisitOrderVerifyingVisitor ? target : new VisitOrderVerifyingVisitor(target);
-
-		if (delegate.visitHeader()) {
-			delegate.visitNamespaces(MappingUtil.NS_SOURCE_FALLBACK, Arrays.asList(MappingUtil.NS_TARGET_FALLBACK, MappingUtil.NS_TARGET_FALLBACK + "2"));
-			delegate.visitMetadata("name", "valid");
-			delegate.visitMetadata(MigrationMapConstants.ORDER_KEY, "0");
-		}
-
-		if (delegate.visitContent()) {
-			int[] dstNs = new int[] { 0, 1 };
-			NameGen nameGen = new NameGen();
-
-			if (nameGen.visitClass(delegate, dstNs)) {
-				nameGen.visitField(delegate, dstNs);
-
-				if (nameGen.visitMethod(delegate, dstNs)) {
-					nameGen.visitMethodArg(delegate, dstNs);
-					nameGen.visitMethodVar(delegate, dstNs);
-				}
-			}
-
-			if (nameGen.visitInnerClass(delegate, 1, dstNs)) {
-				nameGen.visitComment(delegate);
-				nameGen.visitField(delegate, dstNs);
-			}
-
-			nameGen.visitClass(delegate, dstNs);
-		}
-
-		if (!delegate.visitEnd()) {
-			acceptTestMappings(delegate);
-		}
-
-		return target;
-	}
-
-	// After any changes, run "./gradlew updateTestMappings" to update the mapping files in the resources folder accordingly.
-	// Make sure to keep the few manual changes in the files.
-	public static <T extends MappingVisitor> T acceptTestMappingsWithRepeats(T target, boolean repeatComments, boolean repeatClasses) throws IOException {
-		acceptTestMappings(new ForwardingMappingVisitor(new VisitOrderVerifyingVisitor(target, true)) {
-			private final List<Runnable> replayQueue = new ArrayList<>();
-
-			@Override
-			public void visitMetadata(String key, @Nullable String value) throws IOException {
-				super.visitMetadata(key, key.equals("name") ? "repeated-elements" : value);
-			}
-
-			@Override
-			public boolean visitClass(String srcName) throws IOException {
-				replayQueue.clear();
-
-				if (repeatClasses) {
-					replayQueue.add(Unchecked.runnable(() -> super.visitClass(srcName)));
-				}
-
-				return super.visitClass(srcName);
-			}
-
-			@Override
-			public boolean visitField(String srcName, @Nullable String srcDesc) throws IOException {
-				replayQueue.clear();
-				replayQueue.add(Unchecked.runnable(() -> super.visitField(srcName, srcDesc)));
-				return super.visitField(srcName, srcDesc);
-			}
-
-			@Override
-			public boolean visitMethod(String srcName, @Nullable String srcDesc) throws IOException {
-				replayQueue.clear();
-				replayQueue.add(Unchecked.runnable(() -> super.visitMethod(srcName, srcDesc)));
-				return super.visitMethod(srcName, srcDesc);
-			}
-
-			@Override
-			public boolean visitMethodArg(int lvIndex, int argIndex, String srcName) throws IOException {
-				replayQueue.clear();
-				replayQueue.add(Unchecked.runnable(() -> super.visitMethodArg(lvIndex, argIndex, srcName)));
-				return super.visitMethodArg(lvIndex, argIndex, srcName);
-			}
-
-			@Override
-			public boolean visitMethodVar(int lvIndex, int varIndex, int startOpIdx, int endOpIdx, String srcName) throws IOException {
-				replayQueue.clear();
-				replayQueue.add(Unchecked.runnable(() -> super.visitMethodVar(lvIndex, varIndex, startOpIdx, endOpIdx, srcName)));
-				return super.visitMethodVar(lvIndex, varIndex, startOpIdx, endOpIdx, srcName);
-			}
-
-			@Override
-			public void visitDstName(MappedElementKind targetKind, int namespace, String name) throws IOException {
-				if (targetKind == MappedElementKind.CLASS && !repeatClasses) {
-					super.visitDstName(targetKind, namespace, name);
-				} else {
-					replayQueue.add(Unchecked.runnable(() -> super.visitDstName(targetKind, namespace, name)));
-					super.visitDstName(targetKind, namespace, name + "0");
-				}
-			}
-
-			@Override
-			public void visitDstDesc(MappedElementKind targetKind, int namespace, String desc) throws IOException {
-				replayQueue.add(Unchecked.runnable(() -> super.visitDstDesc(targetKind, namespace, desc)));
-				super.visitDstDesc(targetKind, namespace, desc);
-			}
-
-			@Override
-			public boolean visitElementContent(MappedElementKind targetKind) throws IOException {
-				boolean ret = super.visitElementContent(targetKind);
-
-				if (!replayQueue.isEmpty()) {
-					replayQueue.forEach(Runnable::run);
-
-					ret = super.visitElementContent(targetKind);
-				}
-
-				return ret;
-			}
-
-			@Override
-			public void visitComment(MappedElementKind targetKind, String comment) throws IOException {
-				if (repeatComments) {
-					super.visitComment(targetKind, comment + ".");
-				}
-
-				super.visitComment(targetKind, comment);
-			}
-		});
-
-		return target;
-	}
-
-	// After any changes, run "./gradlew updateTestMappings" to update the mapping files in the resources folder accordingly
-	public static <T extends MappingVisitor> T acceptTestMappingsWithHoles(T target) throws IOException {
-		MappingVisitor delegate = target instanceof VisitOrderVerifyingVisitor ? target : new VisitOrderVerifyingVisitor(target);
-
-		if (delegate.visitHeader()) {
-			delegate.visitNamespaces(MappingUtil.NS_SOURCE_FALLBACK, Arrays.asList(MappingUtil.NS_TARGET_FALLBACK, MappingUtil.NS_TARGET_FALLBACK + "2"));
-		}
-
-		if (delegate.visitContent()) {
-			NameGen nameGen = new NameGen();
-
-			// (Inner) Classes
-			for (int nestLevel = 0; nestLevel <= 2; nestLevel++) {
-				nameGen.visitClass(delegate);
-				nameGen.visitClass(delegate);
-				nameGen.visitInnerClass(delegate, nestLevel, 0);
-				nameGen.visitInnerClass(delegate, nestLevel, 1);
-
-				if (nameGen.visitInnerClass(delegate, nestLevel)) {
-					nameGen.visitComment(delegate);
-				}
-
-				if (nameGen.visitInnerClass(delegate, nestLevel, 0)) {
-					nameGen.visitComment(delegate);
-				}
-
-				if (nameGen.visitInnerClass(delegate, nestLevel, 1)) {
-					nameGen.visitComment(delegate);
-				}
-			}
-
-			if (nameGen.visitClass(delegate)) {
-				// Fields
-				nameGen.visitField(delegate);
-				nameGen.visitField(delegate, 0);
-				nameGen.visitField(delegate, 1);
-
-				if (nameGen.visitField(delegate)) {
-					nameGen.visitComment(delegate);
-				}
-
-				if (nameGen.visitField(delegate, 0)) {
-					nameGen.visitComment(delegate);
-				}
-
-				if (nameGen.visitField(delegate, 1)) {
-					nameGen.visitComment(delegate);
-				}
-
-				// Methods
-				nameGen.visitMethod(delegate);
-				nameGen.visitMethod(delegate, 0);
-				nameGen.visitMethod(delegate, 1);
-
-				if (nameGen.visitMethod(delegate)) {
-					nameGen.visitComment(delegate);
-				}
-
-				if (nameGen.visitMethod(delegate, 0)) {
-					nameGen.visitComment(delegate);
-				}
-
-				if (nameGen.visitMethod(delegate, 1)) {
-					nameGen.visitComment(delegate);
-				}
-
-				// Method args
-				if (nameGen.visitMethod(delegate)) {
-					nameGen.visitMethodArg(delegate);
-					nameGen.visitMethodArg(delegate, 1);
-					nameGen.visitMethodArg(delegate, 0);
-
-					if (nameGen.visitMethodArg(delegate)) {
-						nameGen.visitComment(delegate);
-					}
-
-					if (nameGen.visitMethodArg(delegate, 0)) {
-						nameGen.visitComment(delegate);
-					}
-
-					if (nameGen.visitMethodArg(delegate, 1)) {
-						nameGen.visitComment(delegate);
-					}
-				}
-
-				// Method vars
-				if (nameGen.visitMethod(delegate)) {
-					nameGen.visitMethodVar(delegate);
-					nameGen.visitMethodVar(delegate, 1);
-					nameGen.visitMethodVar(delegate, 0);
-
-					if (nameGen.visitMethodVar(delegate)) {
-						nameGen.visitComment(delegate);
-					}
-
-					if (nameGen.visitMethodVar(delegate, 0)) {
-						nameGen.visitComment(delegate);
-					}
-
-					if (nameGen.visitMethodVar(delegate, 1)) {
-						nameGen.visitComment(delegate);
-					}
-				}
-			}
-		}
-
-		if (!delegate.visitEnd()) {
-			acceptTestMappingsWithHoles(delegate);
-		}
-
-		return target;
-	}
-
-	public static class MappingDirs {
-		@Nullable
-		public static MemoryMappingTree getCorrespondingTree(Path dir) throws IOException {
-			if (dir.equals(VALID)) return acceptTestMappings(new MemoryMappingTree());
-			if (dir.equals(REPEATED_ELEMENTS)) return acceptTestMappingsWithRepeats(new MemoryMappingTree(), true, true);
-			if (dir.equals(HOLES)) return acceptTestMappingsWithHoles(new MemoryMappingTree());
-			return null;
-		}
-
-		public static final Path DETECTION = getResource("/detection/");
-		public static final Path VALID = getResource("/reading/valid/");
-		public static final Path REPEATED_ELEMENTS = getResource("/reading/repeated-elements/");
-		public static final Path HOLES = getResource("/reading/holes/");
-		public static final Path MERGING = getResource("/merging/");
-	}
+	private static Path resourceRoot;
 }

--- a/src/test/java/net/fabricmc/mappingio/test/TestUtil.java
+++ b/src/test/java/net/fabricmc/mappingio/test/TestUtil.java
@@ -30,12 +30,6 @@ import net.fabricmc.mappingio.MappingWriter;
 import net.fabricmc.mappingio.format.MappingFormat;
 import net.fabricmc.mappingio.tree.MappingTreeView;
 
-/*
- * After any changes to the "accept" methods, run the "generateTestMappings" Gradle task
- * to update the mapping files located in the resources folder accordingly.
- *
- * Make sure to keep the manual Enigma and SRG changes in the "repeated-elements" directory.
- */
 public final class TestUtil {
 	public static void setResourceRoot(Path path) {
 		resourceRoot = path;

--- a/src/test/java/net/fabricmc/mappingio/test/lib/jool/Unchecked.java
+++ b/src/test/java/net/fabricmc/mappingio/test/lib/jool/Unchecked.java
@@ -21,6 +21,7 @@ import java.io.UncheckedIOException;
 import java.util.function.Consumer;
 
 import net.fabricmc.mappingio.test.lib.jool.fi.lang.CheckedRunnable;
+import net.fabricmc.mappingio.test.lib.jool.fi.util.function.CheckedConsumer;
 
 /**
  * Improved interoperability between checked exceptions and Java 8.
@@ -95,6 +96,50 @@ public class Unchecked {
 			try {
 				runnable.run();
 			} catch (Throwable e) {
+				handler.accept(e);
+
+				throw new IllegalStateException("Exception handler must throw a RuntimeException", e);
+			}
+		};
+	}
+
+	/**
+	 * Wrap a {@link CheckedConsumer} in a {@link Consumer}.
+	 * <p>
+	 * Example:
+	 * <pre><code>
+	 * Arrays.asList("a", "b").stream().forEach(Unchecked.consumer(s -> {
+	 *     if (s.length() > 10)
+	 *         throw new Exception("Only short strings allowed");
+	 * }));
+	 * </code></pre>
+	 */
+	public static <T> Consumer<T> consumer(CheckedConsumer<T> consumer) {
+		return consumer(consumer, THROWABLE_TO_RUNTIME_EXCEPTION);
+	}
+
+	/**
+	 * Wrap a {@link CheckedConsumer} in a {@link Consumer} with a custom handler for checked exceptions.
+	 * <p>
+	 * Example:
+	 * <pre><code>
+	 * Arrays.asList("a", "b").stream().forEach(Unchecked.consumer(
+	 *     s -> {
+	 *         if (s.length() > 10)
+	 *             throw new Exception("Only short strings allowed");
+	 *     },
+	 *     e -> {
+	 *         throw new IllegalStateException(e);
+	 *     }
+	 * ));
+	 * </code></pre>
+	 */
+	public static <T> Consumer<T> consumer(CheckedConsumer<T> consumer, Consumer<Throwable> handler) {
+		return t -> {
+			try {
+				consumer.accept(t);
+			}
+			catch (Throwable e) {
 				handler.accept(e);
 
 				throw new IllegalStateException("Exception handler must throw a RuntimeException", e);

--- a/src/test/java/net/fabricmc/mappingio/test/lib/jool/Unchecked.java
+++ b/src/test/java/net/fabricmc/mappingio/test/lib/jool/Unchecked.java
@@ -105,8 +105,8 @@ public class Unchecked {
 
 	/**
 	 * Wrap a {@link CheckedConsumer} in a {@link Consumer}.
-	 * <p>
-	 * Example:
+	 *
+	 * <p>Example:
 	 * <pre><code>
 	 * Arrays.asList("a", "b").stream().forEach(Unchecked.consumer(s -> {
 	 *     if (s.length() > 10)
@@ -120,8 +120,8 @@ public class Unchecked {
 
 	/**
 	 * Wrap a {@link CheckedConsumer} in a {@link Consumer} with a custom handler for checked exceptions.
-	 * <p>
-	 * Example:
+	 *
+	 * <p>Example:
 	 * <pre><code>
 	 * Arrays.asList("a", "b").stream().forEach(Unchecked.consumer(
 	 *     s -> {
@@ -138,8 +138,7 @@ public class Unchecked {
 		return t -> {
 			try {
 				consumer.accept(t);
-			}
-			catch (Throwable e) {
+			} catch (Throwable e) {
 				handler.accept(e);
 
 				throw new IllegalStateException("Exception handler must throw a RuntimeException", e);

--- a/src/test/java/net/fabricmc/mappingio/test/lib/jool/fi/util/function/CheckedConsumer.java
+++ b/src/test/java/net/fabricmc/mappingio/test/lib/jool/fi/util/function/CheckedConsumer.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c), Data Geekery GmbH, contact@datageekery.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.mappingio.test.lib.jool.fi.util.function;
+
+import java.util.function.Consumer;
+
+import net.fabricmc.mappingio.test.lib.jool.Unchecked;
+
+/**
+ * A {@link Consumer} that allows for checked exceptions.
+ *
+ * @author Lukas Eder
+ */
+@FunctionalInterface
+public interface CheckedConsumer<T> {
+
+    /**
+     * Performs this operation on the given argument.
+     *
+     * @param t the input argument
+     */
+    void accept(T t) throws Throwable;
+
+    /**
+     * @see {@link Unchecked#consumer(CheckedConsumer)}
+     */
+    static <T> Consumer<T> unchecked(CheckedConsumer<T> consumer) {
+        return Unchecked.consumer(consumer);
+    }
+
+    /**
+     * @see {@link Unchecked#consumer(CheckedConsumer, Consumer)}
+     */
+    static <T> Consumer<T> unchecked(CheckedConsumer<T> consumer, Consumer<Throwable> handler) {
+        return Unchecked.consumer(consumer, handler);
+    }
+}

--- a/src/test/java/net/fabricmc/mappingio/test/lib/jool/fi/util/function/CheckedConsumer.java
+++ b/src/test/java/net/fabricmc/mappingio/test/lib/jool/fi/util/function/CheckedConsumer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c), Data Geekery GmbH, contact@datageekery.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,8 +18,6 @@ package net.fabricmc.mappingio.test.lib.jool.fi.util.function;
 
 import java.util.function.Consumer;
 
-import net.fabricmc.mappingio.test.lib.jool.Unchecked;
-
 /**
  * A {@link Consumer} that allows for checked exceptions.
  *
@@ -27,25 +25,10 @@ import net.fabricmc.mappingio.test.lib.jool.Unchecked;
  */
 @FunctionalInterface
 public interface CheckedConsumer<T> {
-
-    /**
-     * Performs this operation on the given argument.
-     *
-     * @param t the input argument
-     */
-    void accept(T t) throws Throwable;
-
-    /**
-     * @see {@link Unchecked#consumer(CheckedConsumer)}
-     */
-    static <T> Consumer<T> unchecked(CheckedConsumer<T> consumer) {
-        return Unchecked.consumer(consumer);
-    }
-
-    /**
-     * @see {@link Unchecked#consumer(CheckedConsumer, Consumer)}
-     */
-    static <T> Consumer<T> unchecked(CheckedConsumer<T> consumer, Consumer<Throwable> handler) {
-        return Unchecked.consumer(consumer, handler);
-    }
+	/**
+	 * Performs this operation on the given argument.
+	 *
+	 * @param t the input argument
+	 */
+	void accept(T t) throws Throwable;
 }

--- a/src/test/java/net/fabricmc/mappingio/test/tests/reading/DetectionTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/reading/DetectionTest.java
@@ -30,98 +30,26 @@ import org.opentest4j.AssertionFailedError;
 
 import net.fabricmc.mappingio.MappingReader;
 import net.fabricmc.mappingio.format.MappingFormat;
-import net.fabricmc.mappingio.test.TestUtil;
+import net.fabricmc.mappingio.test.TestMappings;
+import net.fabricmc.mappingio.test.TestMappings.MappingDir;
 import net.fabricmc.mappingio.test.visitors.NopMappingVisitor;
 
 public class DetectionTest {
-	private static final Path dir = TestUtil.MappingDirs.DETECTION;
+	private static final MappingDir dir = TestMappings.DETECTION;
 
 	@Test
-	public void enigmaFile() throws Exception {
-		MappingFormat format = MappingFormat.ENIGMA_FILE;
-		check(format);
-	}
-
-	@Test
-	public void enigmaDirectory() throws Exception {
-		MappingFormat format = MappingFormat.ENIGMA_DIR;
-		check(format);
-	}
-
-	@Test
-	public void tinyFile() throws Exception {
-		MappingFormat format = MappingFormat.TINY_FILE;
-		check(format);
-	}
-
-	@Test
-	public void tinyV2File() throws Exception {
-		MappingFormat format = MappingFormat.TINY_2_FILE;
-		check(format);
-	}
-
-	@Test
-	public void srgFile() throws Exception {
-		MappingFormat format = MappingFormat.SRG_FILE;
-		check(format);
-	}
-
-	@Test
-	public void xsrgFile() throws Exception {
-		MappingFormat format = MappingFormat.XSRG_FILE;
-		check(format);
-	}
-
-	@Test
-	public void jamFile() throws Exception {
-		MappingFormat format = MappingFormat.JAM_FILE;
-		check(format);
-	}
-
-	@Test
-	public void csrgFile() throws Exception {
-		MappingFormat format = MappingFormat.CSRG_FILE;
-		check(format);
-	}
-
-	@Test
-	public void tsrgFile() throws Exception {
-		MappingFormat format = MappingFormat.TSRG_FILE;
-		check(format);
-	}
-
-	@Test
-	public void tsrgV2File() throws Exception {
-		MappingFormat format = MappingFormat.TSRG_2_FILE;
-		check(format);
-	}
-
-	@Test
-	public void proguardFile() throws Exception {
-		MappingFormat format = MappingFormat.PROGUARD_FILE;
-		check(format);
-	}
-
-	@Test
-	public void migrationMapFile() throws Exception {
-		MappingFormat format = MappingFormat.INTELLIJ_MIGRATION_MAP_FILE;
-		check(format);
-	}
-
-	@Test
-	public void recafSimpleFile() throws Exception {
-		MappingFormat format = MappingFormat.RECAF_SIMPLE_FILE;
-		assertThrows(AssertionFailedError.class, () -> check(format));
-	}
-
-	@Test
-	public void jobfFile() throws Exception {
-		MappingFormat format = MappingFormat.JOBF_FILE;
-		check(format);
+	public void run() throws Exception {
+		for (MappingFormat format : MappingFormat.values()) {
+			if (format == MappingFormat.RECAF_SIMPLE_FILE) {
+				assertThrows(AssertionFailedError.class, () -> check(format));
+			} else {
+				check(format);
+			}
+		}
 	}
 
 	private void check(MappingFormat format) throws Exception {
-		Path path = dir.resolve(TestUtil.getFileName(format));
+		Path path = dir.pathFor(format);
 		assertEquals(format, MappingReader.detectFormat(path));
 
 		if (!format.hasSingleFile()) return;

--- a/src/test/java/net/fabricmc/mappingio/test/tests/reading/EmptyContentReadTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/reading/EmptyContentReadTest.java
@@ -47,11 +47,6 @@ public class EmptyContentReadTest {
 	}
 
 	@Test
-	public void emptyEnigmaFile() throws Exception {
-		EnigmaFileReader.read(new StringReader(""), target);
-	}
-
-	@Test
 	public void emptyTinyFile() throws Exception {
 		String header0 = "";
 		String header1 = "v1";
@@ -86,12 +81,17 @@ public class EmptyContentReadTest {
 	}
 
 	@Test
+	public void emptyEnigmaFile() throws Exception {
+		EnigmaFileReader.read(new StringReader(""), target);
+	}
+
+	@Test
 	public void emptyProguardFile() throws Exception {
 		ProGuardFileReader.read(new StringReader(""), target);
 	}
 
 	@Test
-	public void emptySrgFile() throws Exception {
+	public void emptySrgOrXsrgFile() throws Exception {
 		SrgFileReader.read(new StringReader(""), target);
 	}
 
@@ -101,7 +101,7 @@ public class EmptyContentReadTest {
 	}
 
 	@Test
-	public void emptyTsrgFile() throws Exception {
+	public void emptyCsrgOrTsrgFile() throws Exception {
 		String header0 = "";
 		String header1 = "tsrg2";
 		String header2 = header1 + " ";

--- a/src/test/java/net/fabricmc/mappingio/test/tests/tree/MergeTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/tree/MergeTest.java
@@ -33,7 +33,7 @@ import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingReader;
 import net.fabricmc.mappingio.MappingVisitor;
 import net.fabricmc.mappingio.adapter.FlatAsRegularMappingVisitor;
-import net.fabricmc.mappingio.test.TestUtil;
+import net.fabricmc.mappingio.test.TestMappings;
 import net.fabricmc.mappingio.test.visitors.SubsetAssertingVisitor;
 import net.fabricmc.mappingio.test.visitors.VisitOrderVerifyingVisitor;
 import net.fabricmc.mappingio.tree.MappingTree.ClassMapping;
@@ -41,7 +41,7 @@ import net.fabricmc.mappingio.tree.MappingTree.FieldMapping;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
 public class MergeTest {
-	private static final Path dir = TestUtil.MappingDirs.MERGING;
+	private static final Path dir = TestMappings.MERGING;
 	private static final String ns1 = "ns1";
 	private static final String ns2 = "ns2";
 	private static final String ns3 = "ns3";

--- a/src/test/java/net/fabricmc/mappingio/test/tests/tree/MetadataTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/tree/MetadataTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import net.fabricmc.mappingio.MappingFlag;
-import net.fabricmc.mappingio.test.TestUtil;
+import net.fabricmc.mappingio.test.TestMappings;
 import net.fabricmc.mappingio.test.visitors.NopMappingVisitor;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
 import net.fabricmc.mappingio.tree.VisitableMappingTree;
@@ -44,7 +44,7 @@ public class MetadataTest {
 
 	@BeforeAll
 	public static void setup() throws Exception {
-		tree = TestUtil.acceptTestMappings(new MemoryMappingTree());
+		tree = TestMappings.generateValid(new MemoryMappingTree());
 		tree.getMetadata().clear();
 
 		for (int i = 0; i < 40; i++) {

--- a/src/test/java/net/fabricmc/mappingio/test/tests/tree/SetNamespacesTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/tree/SetNamespacesTest.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import net.fabricmc.mappingio.test.TestUtil;
+import net.fabricmc.mappingio.test.TestMappings;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
 public class SetNamespacesTest {
@@ -36,8 +36,7 @@ public class SetNamespacesTest {
 
 	@BeforeEach
 	public void setup() throws IOException {
-		tree = new MemoryMappingTree();
-		TestUtil.acceptTestMappings(tree);
+		tree = TestMappings.generateValid(new MemoryMappingTree());
 
 		srcNs = tree.getSrcNamespace();
 		dstNs0 = tree.getDstNamespaces().get(0);

--- a/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/csrg.csrg
+++ b/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/csrg.csrg
@@ -1,0 +1,6 @@
+class_1 class1Ns0Rename
+class_1 field_1 field_1
+class_1$class_2 class1Ns0Rename$class_2
+class_1$class_2 field_2 field_2
+class_1$class_2$class_3 class1Ns0Rename$class_2$class_3
+class_1$class_2$class_3 field_2 field_2

--- a/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/enigma-dir/class1Ns0Rename.mapping
+++ b/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/enigma-dir/class1Ns0Rename.mapping
@@ -1,0 +1,6 @@
+CLASS class_1 class1Ns0Rename
+	FIELD field_1 field_1 Lclass_1;
+	CLASS class_2
+		FIELD field_2 field_2 Lclass_1$class_2;
+		CLASS class_3
+			FIELD field_2 field_2 Lclass_1$class_2$class_3;

--- a/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/enigma.mappings
+++ b/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/enigma.mappings
@@ -1,0 +1,6 @@
+CLASS class_1 class1Ns0Rename
+	FIELD field_1 field_1 Lclass_1;
+	CLASS class_2
+		FIELD field_2 field_2 Lclass_1$class_2;
+		CLASS class_3
+			FIELD field_2 field_2 Lclass_1$class_2$class_3;

--- a/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/jam.jam
+++ b/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/jam.jam
@@ -1,0 +1,6 @@
+CL class_1 class1Ns0Rename
+CL class_1$class_2 class1Ns0Rename$class_2
+CL class_1$class_2$class_3 class1Ns0Rename$class_2$class_3
+FD class_1 field_1 Lclass_1; field_1
+FD class_1$class_2 field_2 Lclass_1$class_2; field_2
+FD class_1$class_2$class_3 field_2 Lclass_1$class_2$class_3; field_2

--- a/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/jobf.jobf
+++ b/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/jobf.jobf
@@ -1,0 +1,6 @@
+c class_1 = class1Ns0Rename
+f class_1.field_1:Lclass_1; = field_1
+c class_1$class_2 = class1Ns0Rename$class_2
+f class_1$class_2.field_2:Lclass_1$class_2; = field_2
+c class_1$class_2$class_3 = class1Ns0Rename$class_2$class_3
+f class_1$class_2$class_3.field_2:Lclass_1$class_2$class_3; = field_2

--- a/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/migration-map.xml
+++ b/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/migration-map.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<migrationMap>
+	<entry oldName="class_1" newName="class1Ns0Rename" type="class"/>
+	<entry oldName="class_1$class_2" newName="class1Ns0Rename$class_2" type="class"/>
+	<entry oldName="class_1$class_2$class_3" newName="class1Ns0Rename$class_2$class_3" type="class"/>
+	<name value="Unnamed migration map"/>
+	<order value="0"/>
+</migrationMap>

--- a/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/proguard.txt
+++ b/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/proguard.txt
@@ -1,0 +1,6 @@
+class_1 -> class1Ns0Rename:
+    class_1 field_1 -> field_1
+class_1$class_2 -> class1Ns0Rename$class_2:
+    class_1$class_2 field_2 -> field_2
+class_1$class_2$class_3 -> class1Ns0Rename$class_2$class_3:
+    class_1$class_2$class_3 field_2 -> field_2

--- a/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/recaf-simple.txt
+++ b/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/recaf-simple.txt
@@ -1,0 +1,6 @@
+class_1 class1Ns0Rename
+class_1.field_1 Lclass_1; field_1
+class_1$class_2 class1Ns0Rename$class_2
+class_1$class_2.field_2 Lclass_1$class_2; field_2
+class_1$class_2$class_3 class1Ns0Rename$class_2$class_3
+class_1$class_2$class_3.field_2 Lclass_1$class_2$class_3; field_2

--- a/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/srg.srg
+++ b/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/srg.srg
@@ -1,0 +1,6 @@
+CL: class_1 class1Ns0Rename
+FD: class_1/field_1 class1Ns0Rename/field_1
+CL: class_1$class_2 class1Ns0Rename$class_2
+FD: class_1$class_2/field_2 class1Ns0Rename$class_2/field_2
+CL: class_1$class_2$class_3 class1Ns0Rename$class_2$class_3
+FD: class_1$class_2$class_3/field_2 class1Ns0Rename$class_2$class_3/field_2

--- a/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/tiny.tiny
+++ b/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/tiny.tiny
@@ -1,0 +1,4 @@
+v1	source	dstNs0	dstNs1	dstNs2	dstNs3	dstNs4	dstNs5	dstNs6
+CLASS	class_1	class1Ns0Rename	class1Ns1Rename	class1Ns2Rename		class1Ns4Rename		
+CLASS	class_1$class_2	class1Ns0Rename$class_2	class1Ns1Rename$class_2	class1Ns2Rename$class2Ns2Rename	class_1$class2Ns3Rename	class1Ns4Rename$class_2	class_1$class2Ns5Rename	
+CLASS	class_1$class_2$class_3	class1Ns0Rename$class_2$class_3	class1Ns1Rename$class_2$class_3	class1Ns2Rename$class2Ns2Rename$class_3	class_1$class2Ns3Rename$class_3	class1Ns4Rename$class_2$class_3	class_1$class_2$class3Ns5Rename	class_1$class_2$class3Ns6Rename

--- a/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/tinyV2.tiny
+++ b/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/tinyV2.tiny
@@ -1,0 +1,7 @@
+tiny	2	0	source	dstNs0	dstNs1	dstNs2	dstNs3	dstNs4	dstNs5	dstNs6
+c	class_1	class1Ns0Rename	class1Ns1Rename	class1Ns2Rename		class1Ns4Rename		
+	f	Lclass_1;	field_1							
+c	class_1$class_2	class1Ns0Rename$class_2	class1Ns1Rename$class_2	class1Ns2Rename$class2Ns2Rename	class_1$class2Ns3Rename	class1Ns4Rename$class_2	class_1$class2Ns5Rename	
+	f	Lclass_1$class_2;	field_2							
+c	class_1$class_2$class_3	class1Ns0Rename$class_2$class_3	class1Ns1Rename$class_2$class_3	class1Ns2Rename$class2Ns2Rename$class_3	class_1$class2Ns3Rename$class_3	class1Ns4Rename$class_2$class_3	class_1$class_2$class3Ns5Rename	class_1$class_2$class3Ns6Rename
+	f	Lclass_1$class_2$class_3;	field_2							

--- a/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/tsrg.tsrg
+++ b/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/tsrg.tsrg
@@ -1,0 +1,6 @@
+class_1 class1Ns0Rename
+	field_1 field_1
+class_1$class_2 class1Ns0Rename$class_2
+	field_2 field_2
+class_1$class_2$class_3 class1Ns0Rename$class_2$class_3
+	field_2 field_2

--- a/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/tsrgV2.tsrg
+++ b/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/tsrgV2.tsrg
@@ -1,0 +1,4 @@
+tsrg2 source dstNs0 dstNs1 dstNs2 dstNs3 dstNs4 dstNs5 dstNs6
+class_1 class1Ns0Rename class1Ns1Rename class1Ns2Rename class_1 class1Ns4Rename class_1 class_1
+class_1$class_2 class1Ns0Rename$class_2 class1Ns1Rename$class_2 class1Ns2Rename$class2Ns2Rename class_1$class2Ns3Rename class1Ns4Rename$class_2 class_1$class2Ns5Rename class_1$class_2
+class_1$class_2$class_3 class1Ns0Rename$class_2$class_3 class1Ns1Rename$class_2$class_3 class1Ns2Rename$class2Ns2Rename$class_3 class_1$class2Ns3Rename$class_3 class1Ns4Rename$class_2$class_3 class_1$class_2$class3Ns5Rename class_1$class_2$class3Ns6Rename

--- a/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/xsrg.xsrg
+++ b/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/xsrg.xsrg
@@ -1,0 +1,6 @@
+CL: class_1 class1Ns0Rename
+FD: class_1/field_1 Lclass_1; class1Ns0Rename/field_1 Lclass_1;
+CL: class_1$class_2 class1Ns0Rename$class_2
+FD: class_1$class_2/field_2 Lclass_1$class_2; class1Ns0Rename$class_2/field_2 Lclass1Ns0Rename$class_2;
+CL: class_1$class_2$class_3 class1Ns0Rename$class_2$class_3
+FD: class_1$class_2$class_3/field_2 Lclass_1$class_2$class_3; class1Ns0Rename$class_2$class_3/field_2 Lclass1Ns0Rename$class_2$class_3;

--- a/src/test/resources/outer-class-name-propagation/propagated/csrg.csrg
+++ b/src/test/resources/outer-class-name-propagation/propagated/csrg.csrg
@@ -1,0 +1,6 @@
+class_1 class1Ns0Rename
+class_1 field_1 field_1
+class_1$class_2 class1Ns0Rename$class_2
+class_1$class_2 field_2 field_2
+class_1$class_2$class_3 class1Ns0Rename$class_2$class_3
+class_1$class_2$class_3 field_2 field_2

--- a/src/test/resources/outer-class-name-propagation/propagated/enigma-dir/class1Ns0Rename.mapping
+++ b/src/test/resources/outer-class-name-propagation/propagated/enigma-dir/class1Ns0Rename.mapping
@@ -1,0 +1,6 @@
+CLASS class_1 class1Ns0Rename
+	FIELD field_1 field_1 Lclass_1;
+	CLASS class_2
+		FIELD field_2 field_2 Lclass_1$class_2;
+		CLASS class_3
+			FIELD field_2 field_2 Lclass_1$class_2$class_3;

--- a/src/test/resources/outer-class-name-propagation/propagated/enigma.mappings
+++ b/src/test/resources/outer-class-name-propagation/propagated/enigma.mappings
@@ -1,0 +1,6 @@
+CLASS class_1 class1Ns0Rename
+	FIELD field_1 field_1 Lclass_1;
+	CLASS class_2
+		FIELD field_2 field_2 Lclass_1$class_2;
+		CLASS class_3
+			FIELD field_2 field_2 Lclass_1$class_2$class_3;

--- a/src/test/resources/outer-class-name-propagation/propagated/jam.jam
+++ b/src/test/resources/outer-class-name-propagation/propagated/jam.jam
@@ -1,0 +1,6 @@
+CL class_1 class1Ns0Rename
+CL class_1$class_2 class1Ns0Rename$class_2
+CL class_1$class_2$class_3 class1Ns0Rename$class_2$class_3
+FD class_1 field_1 Lclass_1; field_1
+FD class_1$class_2 field_2 Lclass_1$class_2; field_2
+FD class_1$class_2$class_3 field_2 Lclass_1$class_2$class_3; field_2

--- a/src/test/resources/outer-class-name-propagation/propagated/jobf.jobf
+++ b/src/test/resources/outer-class-name-propagation/propagated/jobf.jobf
@@ -1,0 +1,6 @@
+c class_1 = class1Ns0Rename
+f class_1.field_1:Lclass_1; = field_1
+c class_1$class_2 = class1Ns0Rename$class_2
+f class_1$class_2.field_2:Lclass_1$class_2; = field_2
+c class_1$class_2$class_3 = class1Ns0Rename$class_2$class_3
+f class_1$class_2$class_3.field_2:Lclass_1$class_2$class_3; = field_2

--- a/src/test/resources/outer-class-name-propagation/propagated/migration-map.xml
+++ b/src/test/resources/outer-class-name-propagation/propagated/migration-map.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<migrationMap>
+	<entry oldName="class_1" newName="class1Ns0Rename" type="class"/>
+	<entry oldName="class_1$class_2" newName="class1Ns0Rename$class_2" type="class"/>
+	<entry oldName="class_1$class_2$class_3" newName="class1Ns0Rename$class_2$class_3" type="class"/>
+	<name value="Unnamed migration map"/>
+	<order value="0"/>
+</migrationMap>

--- a/src/test/resources/outer-class-name-propagation/propagated/proguard.txt
+++ b/src/test/resources/outer-class-name-propagation/propagated/proguard.txt
@@ -1,0 +1,6 @@
+class_1 -> class1Ns0Rename:
+    class_1 field_1 -> field_1
+class_1$class_2 -> class1Ns0Rename$class_2:
+    class_1$class_2 field_2 -> field_2
+class_1$class_2$class_3 -> class1Ns0Rename$class_2$class_3:
+    class_1$class_2$class_3 field_2 -> field_2

--- a/src/test/resources/outer-class-name-propagation/propagated/recaf-simple.txt
+++ b/src/test/resources/outer-class-name-propagation/propagated/recaf-simple.txt
@@ -1,0 +1,6 @@
+class_1 class1Ns0Rename
+class_1.field_1 Lclass_1; field_1
+class_1$class_2 class1Ns0Rename$class_2
+class_1$class_2.field_2 Lclass_1$class_2; field_2
+class_1$class_2$class_3 class1Ns0Rename$class_2$class_3
+class_1$class_2$class_3.field_2 Lclass_1$class_2$class_3; field_2

--- a/src/test/resources/outer-class-name-propagation/propagated/srg.srg
+++ b/src/test/resources/outer-class-name-propagation/propagated/srg.srg
@@ -1,0 +1,6 @@
+CL: class_1 class1Ns0Rename
+FD: class_1/field_1 class1Ns0Rename/field_1
+CL: class_1$class_2 class1Ns0Rename$class_2
+FD: class_1$class_2/field_2 class1Ns0Rename$class_2/field_2
+CL: class_1$class_2$class_3 class1Ns0Rename$class_2$class_3
+FD: class_1$class_2$class_3/field_2 class1Ns0Rename$class_2$class_3/field_2

--- a/src/test/resources/outer-class-name-propagation/propagated/tiny.tiny
+++ b/src/test/resources/outer-class-name-propagation/propagated/tiny.tiny
@@ -1,0 +1,4 @@
+v1	source	dstNs0	dstNs1	dstNs2	dstNs3	dstNs4	dstNs5	dstNs6
+CLASS	class_1	class1Ns0Rename	class1Ns1Rename	class1Ns2Rename		class1Ns4Rename		
+CLASS	class_1$class_2	class1Ns0Rename$class_2	class1Ns1Rename$class_2	class1Ns2Rename$class2Ns2Rename	class_1$class2Ns3Rename	class1Ns4Rename$class_2	class_1$class2Ns5Rename	
+CLASS	class_1$class_2$class_3	class1Ns0Rename$class_2$class_3	class1Ns1Rename$class_2$class_3	class1Ns2Rename$class2Ns2Rename$class_3	class_1$class2Ns3Rename$class_3	class1Ns4Rename$class_2$class_3	class_1$class2Ns5Rename$class3Ns5Rename	class_1$class_2$class3Ns6Rename

--- a/src/test/resources/outer-class-name-propagation/propagated/tinyV2.tiny
+++ b/src/test/resources/outer-class-name-propagation/propagated/tinyV2.tiny
@@ -1,0 +1,7 @@
+tiny	2	0	source	dstNs0	dstNs1	dstNs2	dstNs3	dstNs4	dstNs5	dstNs6
+c	class_1	class1Ns0Rename	class1Ns1Rename	class1Ns2Rename		class1Ns4Rename		
+	f	Lclass_1;	field_1							
+c	class_1$class_2	class1Ns0Rename$class_2	class1Ns1Rename$class_2	class1Ns2Rename$class2Ns2Rename	class_1$class2Ns3Rename	class1Ns4Rename$class_2	class_1$class2Ns5Rename	
+	f	Lclass_1$class_2;	field_2							
+c	class_1$class_2$class_3	class1Ns0Rename$class_2$class_3	class1Ns1Rename$class_2$class_3	class1Ns2Rename$class2Ns2Rename$class_3	class_1$class2Ns3Rename$class_3	class1Ns4Rename$class_2$class_3	class_1$class2Ns5Rename$class3Ns5Rename	class_1$class_2$class3Ns6Rename
+	f	Lclass_1$class_2$class_3;	field_2							

--- a/src/test/resources/outer-class-name-propagation/propagated/tsrg.tsrg
+++ b/src/test/resources/outer-class-name-propagation/propagated/tsrg.tsrg
@@ -1,0 +1,6 @@
+class_1 class1Ns0Rename
+	field_1 field_1
+class_1$class_2 class1Ns0Rename$class_2
+	field_2 field_2
+class_1$class_2$class_3 class1Ns0Rename$class_2$class_3
+	field_2 field_2

--- a/src/test/resources/outer-class-name-propagation/propagated/tsrgV2.tsrg
+++ b/src/test/resources/outer-class-name-propagation/propagated/tsrgV2.tsrg
@@ -1,0 +1,4 @@
+tsrg2 source dstNs0 dstNs1 dstNs2 dstNs3 dstNs4 dstNs5 dstNs6
+class_1 class1Ns0Rename class1Ns1Rename class1Ns2Rename class_1 class1Ns4Rename class_1 class_1
+class_1$class_2 class1Ns0Rename$class_2 class1Ns1Rename$class_2 class1Ns2Rename$class2Ns2Rename class_1$class2Ns3Rename class1Ns4Rename$class_2 class_1$class2Ns5Rename class_1$class_2
+class_1$class_2$class_3 class1Ns0Rename$class_2$class_3 class1Ns1Rename$class_2$class_3 class1Ns2Rename$class2Ns2Rename$class_3 class_1$class2Ns3Rename$class_3 class1Ns4Rename$class_2$class_3 class_1$class2Ns5Rename$class3Ns5Rename class_1$class_2$class3Ns6Rename

--- a/src/test/resources/outer-class-name-propagation/propagated/xsrg.xsrg
+++ b/src/test/resources/outer-class-name-propagation/propagated/xsrg.xsrg
@@ -1,0 +1,6 @@
+CL: class_1 class1Ns0Rename
+FD: class_1/field_1 Lclass_1; class1Ns0Rename/field_1 Lclass_1;
+CL: class_1$class_2 class1Ns0Rename$class_2
+FD: class_1$class_2/field_2 Lclass_1$class_2; class1Ns0Rename$class_2/field_2 Lclass1Ns0Rename$class_2;
+CL: class_1$class_2$class_3 class1Ns0Rename$class_2$class_3
+FD: class_1$class_2$class_3/field_2 Lclass_1$class_2$class_3; class1Ns0Rename$class_2$class_3/field_2 Lclass1Ns0Rename$class_2$class_3;

--- a/src/test/resources/outer-class-name-propagation/unpropagated/csrg.csrg
+++ b/src/test/resources/outer-class-name-propagation/unpropagated/csrg.csrg
@@ -1,0 +1,6 @@
+class_1 class1Ns0Rename
+class_1 field_1 field_1
+class_1$class_2 class_1$class_2
+class_1$class_2 field_2 field_2
+class_1$class_2$class_3 class_1$class_2$class_3
+class_1$class_2$class_3 field_2 field_2

--- a/src/test/resources/outer-class-name-propagation/unpropagated/enigma-dir/class1Ns0Rename.mapping
+++ b/src/test/resources/outer-class-name-propagation/unpropagated/enigma-dir/class1Ns0Rename.mapping
@@ -1,0 +1,2 @@
+CLASS class_1 class1Ns0Rename
+	FIELD field_1 field_1 Lclass_1;

--- a/src/test/resources/outer-class-name-propagation/unpropagated/enigma-dir/class_1.mapping
+++ b/src/test/resources/outer-class-name-propagation/unpropagated/enigma-dir/class_1.mapping
@@ -1,0 +1,5 @@
+CLASS class_1
+	CLASS class_2
+		FIELD field_2 field_2 Lclass_1$class_2;
+		CLASS class_3
+			FIELD field_2 field_2 Lclass_1$class_2$class_3;

--- a/src/test/resources/outer-class-name-propagation/unpropagated/enigma.mappings
+++ b/src/test/resources/outer-class-name-propagation/unpropagated/enigma.mappings
@@ -1,0 +1,6 @@
+CLASS class_1 class1Ns0Rename
+	FIELD field_1 field_1 Lclass_1;
+	CLASS class_2
+		FIELD field_2 field_2 Lclass_1$class_2;
+		CLASS class_3
+			FIELD field_2 field_2 Lclass_1$class_2$class_3;

--- a/src/test/resources/outer-class-name-propagation/unpropagated/jam.jam
+++ b/src/test/resources/outer-class-name-propagation/unpropagated/jam.jam
@@ -1,0 +1,6 @@
+CL class_1 class1Ns0Rename
+CL class_1$class_2 class_1$class_2
+CL class_1$class_2$class_3 class_1$class_2$class_3
+FD class_1 field_1 Lclass_1; field_1
+FD class_1$class_2 field_2 Lclass_1$class_2; field_2
+FD class_1$class_2$class_3 field_2 Lclass_1$class_2$class_3; field_2

--- a/src/test/resources/outer-class-name-propagation/unpropagated/jobf.jobf
+++ b/src/test/resources/outer-class-name-propagation/unpropagated/jobf.jobf
@@ -1,0 +1,6 @@
+c class_1 = class1Ns0Rename
+f class_1.field_1:Lclass_1; = field_1
+c class_1$class_2 = class_1$class_2
+f class_1$class_2.field_2:Lclass_1$class_2; = field_2
+c class_1$class_2$class_3 = class_1$class_2$class_3
+f class_1$class_2$class_3.field_2:Lclass_1$class_2$class_3; = field_2

--- a/src/test/resources/outer-class-name-propagation/unpropagated/migration-map.xml
+++ b/src/test/resources/outer-class-name-propagation/unpropagated/migration-map.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<migrationMap>
+	<entry oldName="class_1" newName="class1Ns0Rename" type="class"/>
+	<entry oldName="class_1$class_2" newName="class_1$class_2" type="class"/>
+	<entry oldName="class_1$class_2$class_3" newName="class_1$class_2$class_3" type="class"/>
+	<name value="Unnamed migration map"/>
+	<order value="0"/>
+</migrationMap>

--- a/src/test/resources/outer-class-name-propagation/unpropagated/proguard.txt
+++ b/src/test/resources/outer-class-name-propagation/unpropagated/proguard.txt
@@ -1,0 +1,6 @@
+class_1 -> class1Ns0Rename:
+    class_1 field_1 -> field_1
+class_1$class_2 -> class_1$class_2:
+    class_1$class_2 field_2 -> field_2
+class_1$class_2$class_3 -> class_1$class_2$class_3:
+    class_1$class_2$class_3 field_2 -> field_2

--- a/src/test/resources/outer-class-name-propagation/unpropagated/recaf-simple.txt
+++ b/src/test/resources/outer-class-name-propagation/unpropagated/recaf-simple.txt
@@ -1,0 +1,6 @@
+class_1 class1Ns0Rename
+class_1.field_1 Lclass_1; field_1
+class_1$class_2 class_1$class_2
+class_1$class_2.field_2 Lclass_1$class_2; field_2
+class_1$class_2$class_3 class_1$class_2$class_3
+class_1$class_2$class_3.field_2 Lclass_1$class_2$class_3; field_2

--- a/src/test/resources/outer-class-name-propagation/unpropagated/srg.srg
+++ b/src/test/resources/outer-class-name-propagation/unpropagated/srg.srg
@@ -1,0 +1,6 @@
+CL: class_1 class1Ns0Rename
+FD: class_1/field_1 class1Ns0Rename/field_1
+CL: class_1$class_2 class_1$class_2
+FD: class_1$class_2/field_2 class_1$class_2/field_2
+CL: class_1$class_2$class_3 class_1$class_2$class_3
+FD: class_1$class_2$class_3/field_2 class_1$class_2$class_3/field_2

--- a/src/test/resources/outer-class-name-propagation/unpropagated/tiny.tiny
+++ b/src/test/resources/outer-class-name-propagation/unpropagated/tiny.tiny
@@ -1,0 +1,4 @@
+v1	source	dstNs0	dstNs1	dstNs2	dstNs3	dstNs4	dstNs5	dstNs6
+CLASS	class_1	class1Ns0Rename	class1Ns1Rename	class1Ns2Rename		class1Ns4Rename		
+CLASS	class_1$class_2			class1Ns2Rename$class2Ns2Rename	class_1$class2Ns3Rename	class_1$class_2	class_1$class2Ns5Rename	
+CLASS	class_1$class_2$class_3						class_1$class_2$class3Ns5Rename	class_1$class_2$class3Ns6Rename

--- a/src/test/resources/outer-class-name-propagation/unpropagated/tinyV2.tiny
+++ b/src/test/resources/outer-class-name-propagation/unpropagated/tinyV2.tiny
@@ -1,0 +1,7 @@
+tiny	2	0	source	dstNs0	dstNs1	dstNs2	dstNs3	dstNs4	dstNs5	dstNs6
+c	class_1	class1Ns0Rename	class1Ns1Rename	class1Ns2Rename		class1Ns4Rename		
+	f	Lclass_1;	field_1							
+c	class_1$class_2			class1Ns2Rename$class2Ns2Rename	class_1$class2Ns3Rename	class_1$class_2	class_1$class2Ns5Rename	
+	f	Lclass_1$class_2;	field_2							
+c	class_1$class_2$class_3						class_1$class_2$class3Ns5Rename	class_1$class_2$class3Ns6Rename
+	f	Lclass_1$class_2$class_3;	field_2							

--- a/src/test/resources/outer-class-name-propagation/unpropagated/tsrg.tsrg
+++ b/src/test/resources/outer-class-name-propagation/unpropagated/tsrg.tsrg
@@ -1,0 +1,6 @@
+class_1 class1Ns0Rename
+	field_1 field_1
+class_1$class_2 class_1$class_2
+	field_2 field_2
+class_1$class_2$class_3 class_1$class_2$class_3
+	field_2 field_2

--- a/src/test/resources/outer-class-name-propagation/unpropagated/tsrgV2.tsrg
+++ b/src/test/resources/outer-class-name-propagation/unpropagated/tsrgV2.tsrg
@@ -1,0 +1,4 @@
+tsrg2 source dstNs0 dstNs1 dstNs2 dstNs3 dstNs4 dstNs5 dstNs6
+class_1 class1Ns0Rename class1Ns1Rename class1Ns2Rename class_1 class1Ns4Rename class_1 class_1
+class_1$class_2 class_1$class_2 class_1$class_2 class1Ns2Rename$class2Ns2Rename class_1$class2Ns3Rename class_1$class_2 class_1$class2Ns5Rename class_1$class_2
+class_1$class_2$class_3 class_1$class_2$class_3 class_1$class_2$class_3 class_1$class_2$class_3 class_1$class_2$class_3 class_1$class_2$class_3 class_1$class_2$class3Ns5Rename class_1$class_2$class3Ns6Rename

--- a/src/test/resources/outer-class-name-propagation/unpropagated/xsrg.xsrg
+++ b/src/test/resources/outer-class-name-propagation/unpropagated/xsrg.xsrg
@@ -1,0 +1,6 @@
+CL: class_1 class1Ns0Rename
+FD: class_1/field_1 Lclass_1; class1Ns0Rename/field_1 Lclass_1;
+CL: class_1$class_2 class_1$class_2
+FD: class_1$class_2/field_2 Lclass_1$class_2; class_1$class_2/field_2 Lclass_1$class_2;
+CL: class_1$class_2$class_3 class_1$class_2$class_3
+FD: class_1$class_2$class_3/field_2 Lclass_1$class_2$class_3; class_1$class_2$class_3/field_2 Lclass_1$class_2$class_3;

--- a/src/test/resources/reading/repeated-elements/enigma-dir/class1Ns0Rename.mapping
+++ b/src/test/resources/reading/repeated-elements/enigma-dir/class1Ns0Rename.mapping
@@ -1,0 +1,11 @@
+CLASS class_1 class1Ns0Rename
+	FIELD field_1 field1Ns0Rename0 I
+	FIELD field_1 field1Ns0Rename I
+	METHOD method_1 method1Ns0Rename0 ()I
+	METHOD method_1 method1Ns0Rename ()I
+		ARG 1 param1Ns0Rename0
+		ARG 1 param1Ns0Rename
+	CLASS class_2 class2Ns0Rename
+		COMMENT This is a comment
+		FIELD field_2 field2Ns0Rename0 Lcls;
+		FIELD field_2 field2Ns0Rename Lcls;

--- a/src/test/resources/reading/repeated-elements/enigma-dir/package_3/class3Ns0Rename.mapping
+++ b/src/test/resources/reading/repeated-elements/enigma-dir/package_3/class3Ns0Rename.mapping
@@ -1,0 +1,1 @@
+CLASS class_3 package_3/class3Ns0Rename


### PR DESCRIPTION
The `generateTestMappings` Gradle task also works more reliably now.