### PR TITLE
Restore the ability to read source-namespace-only mapping files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Restore the ability to read source-namespace-only mapping files, even if not spec-compliant
 
 ## [0.7.0] - 2025-01-01
 - Added IntelliJ IDEA migration map reader and writer

--- a/src/main/java/net/fabricmc/mappingio/format/srg/TsrgFileReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/srg/TsrgFileReader.java
@@ -82,12 +82,12 @@ public final class TsrgFileReader {
 			dstNamespaces = new ArrayList<>();
 			String dstNamespace;
 
-			while ((dstNamespace = reader.nextCol()) != null) {
-				if (dstNamespace.isEmpty()) throw new IOException("empty destination namespace in TSRG v2 header");
+			while (!reader.isAtEol()) {
+				dstNamespace = reader.nextCol();
+				if (dstNamespace == null || dstNamespace.isEmpty()) throw new IOException("empty destination namespace in TSRG v2 header");
 				dstNamespaces.add(dstNamespace);
 			}
 
-			if (dstNamespaces.isEmpty()) throw new IOException("no destination namespaces in TSRG v2 header");
 			reader.nextLine(0);
 		} else {
 			if (sourceNs == null || sourceNs.isEmpty()) throw new IllegalArgumentException("provided source namespace must not be null or empty");

--- a/src/main/java/net/fabricmc/mappingio/format/tiny/Tiny1FileReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/tiny/Tiny1FileReader.java
@@ -74,13 +74,13 @@ public final class Tiny1FileReader {
 		List<String> dstNamespaces = new ArrayList<>();
 		String dstNamespace;
 
-		while ((dstNamespace = reader.nextCol()) != null) {
-			if (dstNamespace.isEmpty()) throw new IOException("empty destination namespace in Tiny v1 header");
+		while (!reader.isAtEol()) {
+			dstNamespace = reader.nextCol();
+			if (dstNamespace == null || dstNamespace.isEmpty()) throw new IOException("empty destination namespace in Tiny v1 header");
 			dstNamespaces.add(dstNamespace);
 		}
 
 		int dstNsCount = dstNamespaces.size();
-		if (dstNsCount == 0) throw new IOException("no destination namespaces in Tiny v1 header");
 
 		Set<MappingFlag> flags = visitor.getFlags();
 		MappingVisitor parentVisitor = null;

--- a/src/main/java/net/fabricmc/mappingio/format/tiny/Tiny2FileReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/tiny/Tiny2FileReader.java
@@ -75,13 +75,13 @@ public final class Tiny2FileReader {
 		List<String> dstNamespaces = new ArrayList<>();
 		String dstNamespace;
 
-		while ((dstNamespace = reader.nextCol()) != null) {
-			if (dstNamespace.isEmpty()) throw new IOException("empty destination namespace in Tiny v2 header");
+		while (!reader.isAtEol()) {
+			dstNamespace = reader.nextCol();
+			if (dstNamespace == null || dstNamespace.isEmpty()) throw new IOException("empty destination namespace in Tiny v2 header");
 			dstNamespaces.add(dstNamespace);
 		}
 
 		int dstNsCount = dstNamespaces.size();
-		if (dstNsCount == 0) throw new IOException("no destination namespaces in Tiny v2 header");
 		boolean readerMarked = false;
 
 		if (visitor.getFlags().contains(MappingFlag.NEEDS_MULTIPLE_PASSES)) {

--- a/src/test/java/net/fabricmc/mappingio/test/tests/reading/EmptyContentReadTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/reading/EmptyContentReadTest.java
@@ -63,7 +63,7 @@ public class EmptyContentReadTest {
 		assertThrows(IOException.class, () -> Tiny1FileReader.read(new StringReader(header0), target));
 		assertThrows(IOException.class, () -> Tiny1FileReader.read(new StringReader(header1), target));
 		assertThrows(IOException.class, () -> Tiny1FileReader.read(new StringReader(header2), target));
-		assertThrows(IOException.class, () -> Tiny1FileReader.read(new StringReader(header3), target));
+		Tiny1FileReader.read(new StringReader(header3), target);
 		assertThrows(IOException.class, () -> Tiny1FileReader.read(new StringReader(header4), target));
 		Tiny1FileReader.read(new StringReader(header5), target);
 	}
@@ -80,7 +80,7 @@ public class EmptyContentReadTest {
 		assertThrows(IOException.class, () -> Tiny2FileReader.read(new StringReader(header0), target));
 		assertThrows(IOException.class, () -> Tiny2FileReader.read(new StringReader(header1), target));
 		assertThrows(IOException.class, () -> Tiny2FileReader.read(new StringReader(header2), target));
-		assertThrows(IOException.class, () -> Tiny2FileReader.read(new StringReader(header3), target));
+		Tiny2FileReader.read(new StringReader(header3), target);
 		assertThrows(IOException.class, () -> Tiny2FileReader.read(new StringReader(header4), target));
 		Tiny2FileReader.read(new StringReader(header5), target);
 	}
@@ -113,7 +113,7 @@ public class EmptyContentReadTest {
 		instantiateTree();
 		assertThrows(IOException.class, () -> TsrgFileReader.read(new StringReader(header1), target));
 		assertThrows(IOException.class, () -> TsrgFileReader.read(new StringReader(header2), target));
-		assertThrows(IOException.class, () -> TsrgFileReader.read(new StringReader(header3), target));
+		TsrgFileReader.read(new StringReader(header3), target);
 		assertThrows(IOException.class, () -> TsrgFileReader.read(new StringReader(header4), target));
 		TsrgFileReader.read(new StringReader(header5), target);
 	}


### PR DESCRIPTION
This isn't spec-compliant, but is used for [mod-provided Javadocs](https://github.com/FabricMC/fabric-loom/pull/627) in Loom and has some valid use cases. Once #94 is ready, this should log a warning.