### PR TITLE
Make Enigma writer always output destination name if visited explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Made `OuterClassNamePropagator` configurable
+- Made Enigma writer always output destination names if visited explicitly, establishing consistency across all writers
 - Added a simplified `MappingNsCompleter` constructor for completing all destination names with the source names
 
 ## [0.7.1] - 2025-01-07

--- a/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaFileWriter.java
+++ b/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaFileWriter.java
@@ -19,7 +19,6 @@ package net.fabricmc.mappingio.format.enigma;
 import java.io.IOException;
 import java.io.Writer;
 
-import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.format.MappingFormat;
 
 /**
@@ -31,17 +30,7 @@ public final class EnigmaFileWriter extends EnigmaWriterBase {
 	}
 
 	@Override
-	public boolean visitElementContent(MappedElementKind targetKind) throws IOException {
-		if (targetKind == MappedElementKind.CLASS) {
-			writeMismatchedOrMissingClasses();
-		} else if (targetKind == MappedElementKind.FIELD || targetKind == MappedElementKind.METHOD) {
-			writer.write(' ');
-			writer.write(desc);
-			writer.write('\n');
-		} else {
-			writer.write('\n');
-		}
-
-		return true;
+	void visitClassContent() throws IOException {
+		writeMismatchedOrMissingClasses();
 	}
 }

--- a/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaWriterBase.java
+++ b/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaWriterBase.java
@@ -106,7 +106,21 @@ abstract class EnigmaWriterBase implements MappingWriter {
 	}
 
 	@Override
-	public abstract boolean visitElementContent(MappedElementKind targetKind) throws IOException;
+	public final boolean visitElementContent(MappedElementKind targetKind) throws IOException {
+		if (targetKind == MappedElementKind.CLASS) {
+			visitClassContent();
+		} else if (targetKind == MappedElementKind.FIELD || targetKind == MappedElementKind.METHOD) {
+			writer.write(' ');
+			writer.write(desc);
+			writer.write('\n');
+		} else {
+			writer.write('\n');
+		}
+
+		return true;
+	}
+
+	abstract void visitClassContent() throws IOException;
 
 	protected static int getNextOuterEnd(String name, int startPos) {
 		int pos;
@@ -185,7 +199,8 @@ abstract class EnigmaWriterBase implements MappingWriter {
 						if (dstEnd < 0) dstEnd = dstName.length();
 						int dstLen = dstEnd - dstStart;
 
-						if (dstLen != srcLen || !srcClassName.regionMatches(srcStart, dstName, dstStart, srcLen)) { // src != dst
+						if (dstLen != srcLen || !srcClassName.regionMatches(srcStart, dstName, dstStart, srcLen) // src != dst
+								|| dstEnd == dstName.length()) { // always write innermost destination name
 							writer.write(' ');
 							writer.write(dstName, dstStart, dstLen);
 						}

--- a/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/enigma-dir/class1Ns0Rename.mapping
+++ b/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/enigma-dir/class1Ns0Rename.mapping
@@ -1,6 +1,6 @@
 CLASS class_1 class1Ns0Rename
 	FIELD field_1 field_1 Lclass_1;
-	CLASS class_2
+	CLASS class_2 class_2
 		FIELD field_2 field_2 Lclass_1$class_2;
-		CLASS class_3
+		CLASS class_3 class_3
 			FIELD field_2 field_2 Lclass_1$class_2$class_3;

--- a/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/enigma.mappings
+++ b/src/test/resources/outer-class-name-propagation/propagated-except-remapped-dst/enigma.mappings
@@ -1,6 +1,6 @@
 CLASS class_1 class1Ns0Rename
 	FIELD field_1 field_1 Lclass_1;
-	CLASS class_2
+	CLASS class_2 class_2
 		FIELD field_2 field_2 Lclass_1$class_2;
-		CLASS class_3
+		CLASS class_3 class_3
 			FIELD field_2 field_2 Lclass_1$class_2$class_3;

--- a/src/test/resources/outer-class-name-propagation/propagated/enigma-dir/class1Ns0Rename.mapping
+++ b/src/test/resources/outer-class-name-propagation/propagated/enigma-dir/class1Ns0Rename.mapping
@@ -1,6 +1,6 @@
 CLASS class_1 class1Ns0Rename
 	FIELD field_1 field_1 Lclass_1;
-	CLASS class_2
+	CLASS class_2 class_2
 		FIELD field_2 field_2 Lclass_1$class_2;
-		CLASS class_3
+		CLASS class_3 class_3
 			FIELD field_2 field_2 Lclass_1$class_2$class_3;

--- a/src/test/resources/outer-class-name-propagation/propagated/enigma.mappings
+++ b/src/test/resources/outer-class-name-propagation/propagated/enigma.mappings
@@ -1,6 +1,6 @@
 CLASS class_1 class1Ns0Rename
 	FIELD field_1 field_1 Lclass_1;
-	CLASS class_2
+	CLASS class_2 class_2
 		FIELD field_2 field_2 Lclass_1$class_2;
-		CLASS class_3
+		CLASS class_3 class_3
 			FIELD field_2 field_2 Lclass_1$class_2$class_3;

--- a/src/test/resources/outer-class-name-propagation/unpropagated/enigma-dir/class_1.mapping
+++ b/src/test/resources/outer-class-name-propagation/unpropagated/enigma-dir/class_1.mapping
@@ -1,5 +1,5 @@
 CLASS class_1
-	CLASS class_2
+	CLASS class_2 class_2
 		FIELD field_2 field_2 Lclass_1$class_2;
-		CLASS class_3
+		CLASS class_3 class_3
 			FIELD field_2 field_2 Lclass_1$class_2$class_3;

--- a/src/test/resources/outer-class-name-propagation/unpropagated/enigma.mappings
+++ b/src/test/resources/outer-class-name-propagation/unpropagated/enigma.mappings
@@ -1,6 +1,6 @@
 CLASS class_1 class1Ns0Rename
 	FIELD field_1 field_1 Lclass_1;
-	CLASS class_2
+	CLASS class_2 class_2
 		FIELD field_2 field_2 Lclass_1$class_2;
-		CLASS class_3
+		CLASS class_3 class_3
 			FIELD field_2 field_2 Lclass_1$class_2$class_3;


### PR DESCRIPTION
Currently, the destination name is always omitted if equal to the source name, which is not in line with how the other writers behave. This PR forces the innermost destination name to always be written.

Addresses #116.