### PR TITLE
Allow removing mapping tree elements using collections

### DIFF
--- a/src/main/java/net/fabricmc/mappingio/tree/MappingElementCollectionView.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MappingElementCollectionView.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2025 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.mappingio.tree;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+final class MappingElementCollectionView<E> implements Collection<E> {
+	MappingElementCollectionView(MemoryMappingTree owner, Collection<E> backing) {
+		this.owner = owner;
+		this.backing = backing;
+	}
+
+	@Override
+	public int size() {
+		return backing.size();
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return backing.isEmpty();
+	}
+
+	@Override
+	public boolean contains(Object o) {
+		return backing.contains(o);
+	}
+
+	@Override
+	public boolean containsAll(Collection<?> c) {
+		return backing.containsAll(c);
+	}
+
+	@Override
+	public Iterator<E> iterator() {
+		return new IteratorWrapper(backing.iterator());
+	}
+
+	@Override
+	public Object[] toArray() {
+		return backing.toArray();
+	}
+
+	@Override
+	public <T> T[] toArray(T[] a) {
+		return backing.toArray(a);
+	}
+
+	// Mutating methods
+
+	@Override
+	public boolean add(E e) {
+		throw new UnsupportedOperationException("Adding children to mapping elements using collections is not allowed");
+	}
+
+	@Override
+	public boolean addAll(Collection<? extends E> c) {
+		throw new UnsupportedOperationException("Adding children to mapping elements using collections is not allowed");
+	}
+
+	@Override
+	public boolean remove(Object o) {
+		owner.assertNotInVisitPass();
+		return backing.remove(o);
+	}
+
+	@Override
+	public boolean removeAll(Collection<?> c) {
+		owner.assertNotInVisitPass();
+		return backing.removeAll(c);
+	}
+
+	@Override
+	public boolean retainAll(Collection<?> c) {
+		owner.assertNotInVisitPass();
+		return backing.retainAll(c);
+	}
+
+	@Override
+	public void clear() {
+		owner.assertNotInVisitPass();
+	}
+
+	private final MemoryMappingTree owner;
+	private final Collection<E> backing;
+
+	private final class IteratorWrapper implements Iterator<E> {
+		IteratorWrapper(Iterator<E> backing) {
+			this.backing = backing;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return backing.hasNext();
+		}
+
+		@Override
+		public E next() {
+			return backing.next();
+		}
+
+		@Override
+		public void remove() {
+			owner.assertNotInVisitPass();
+			backing.remove();
+		}
+
+		private final Iterator<E> backing;
+	}
+}

--- a/src/main/java/net/fabricmc/mappingio/tree/MappingElementListView.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MappingElementListView.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.mappingio.tree;
+
+import java.util.AbstractList;
+import java.util.List;
+
+final class MappingElementListView<E> extends AbstractList<E> {
+	MappingElementListView(MemoryMappingTree owner, List<E> backing) {
+		this.owner = owner;
+		this.backing = backing;
+	}
+
+	@Override
+	public int size() {
+		return backing.size();
+	}
+
+	@Override
+	public E get(int index) {
+		return backing.get(index);
+	}
+
+	@Override
+	public E remove(int index) {
+		owner.assertNotInVisitPass();
+		return backing.remove(index);
+	}
+
+	private final MemoryMappingTree owner;
+	private final List<E> backing;
+}

--- a/src/main/java/net/fabricmc/mappingio/tree/MappingTree.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MappingTree.java
@@ -30,6 +30,8 @@ import net.fabricmc.mappingio.adapter.MappingSourceNsSwitch;
  * Mutable mapping tree.
  *
  * <p>All returned collections are to be assumed unmodifiable, unless explicitly stated otherwise.
+ * Collections containing {@linkplain MappingTree.ElementMapping tree elements} and their children support removals,
+ * except during visitation passes.
  */
 public interface MappingTree extends MappingTreeView {
 	/**

--- a/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
@@ -1067,7 +1067,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 
 			if (fields == null) {
 				fields = new LinkedHashMap<>();
-				fieldsView = Collections.unmodifiableCollection(fields.values());
+				fieldsView = new MappingElementCollectionView<>(tree, fields.values());
 			}
 
 			return addMember(entry, fields, FLAG_HAS_ANY_FIELD_DESC, FLAG_MISSES_ANY_FIELD_DESC);
@@ -1114,7 +1114,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 
 			if (methods == null) {
 				methods = new LinkedHashMap<>();
-				methodsView = Collections.unmodifiableCollection(methods.values());
+				methodsView = new MappingElementCollectionView<>(tree, methods.values());
 			}
 
 			return addMember(entry, methods, FLAG_HAS_ANY_METHOD_DESC, FLAG_MISSES_ANY_METHOD_DESC);
@@ -1556,7 +1556,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 			if (prev == null) {
 				if (args == null) {
 					args = new ArrayList<>();
-					argsView = Collections.unmodifiableList(args);
+					argsView = new MappingElementListView<>(tree, args);
 				}
 
 				args.add(entry);
@@ -1673,7 +1673,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 			if (prev == null) {
 				if (vars == null) {
 					vars = new ArrayList<>();
-					varsView = Collections.unmodifiableList(vars);
+					varsView = new MappingElementListView<>(tree, vars);
 				}
 
 				vars.add(entry);
@@ -2104,7 +2104,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 	private List<String> dstNamespaces = Collections.emptyList();
 	private final List<MetadataEntry> metadata = new ArrayList<>();
 	private final Map<String, ClassEntry> classesBySrcName = new LinkedHashMap<>();
-	private final Collection<ClassEntry> classesView = Collections.unmodifiableCollection(classesBySrcName.values());
+	private final Collection<ClassEntry> classesView = new MappingElementCollectionView<>(this, classesBySrcName.values());
 	private Map<String, ClassEntry>[] classesByDstNames;
 
 	private HierarchyInfoProvider<?> hierarchyInfo;


### PR DESCRIPTION
WIP/proof of concept.

- Is a set of `clear` methods a better alternative? Existing Architectury code also uses `removeIf` on these collections.
- Shouldn't probably be allowed on classes since they have an index etc
- The collections could also delegate to the `removeXyz` API methods instead, which would be safer
- Needs tests