### PR TITLE
Support merging with disassociated source namespace

### DIFF
--- a/mapping-io-extras/src/test/java/net/fabricmc/mappingio/extras/MappingTreeRemapperTest.java
+++ b/mapping-io-extras/src/test/java/net/fabricmc/mappingio/extras/MappingTreeRemapperTest.java
@@ -18,6 +18,7 @@ package net.fabricmc.mappingio.extras;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static net.fabricmc.mappingio.test.TestUtil.createTree;
 
 import java.io.IOException;
 
@@ -30,7 +31,6 @@ import net.fabricmc.mappingio.tree.MappingTree;
 import net.fabricmc.mappingio.tree.MappingTree.ClassMapping;
 import net.fabricmc.mappingio.tree.MappingTree.FieldMapping;
 import net.fabricmc.mappingio.tree.MappingTree.MethodMapping;
-import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
 public class MappingTreeRemapperTest {
 	private static final String cls1SrcName = "class_1";
@@ -50,7 +50,7 @@ public class MappingTreeRemapperTest {
 
 	@BeforeAll
 	public static void setup() throws IOException {
-		mappingTree = TestMappings.generateValid(new MemoryMappingTree());
+		mappingTree = TestMappings.generateValid(createTree());
 		srcNs = mappingTree.getSrcNamespace();
 		dstNs = mappingTree.getDstNamespaces().get(0);
 

--- a/mapping-io-extras/src/test/java/net/fabricmc/mappingio/extras/MappingTreeRemapperTest.java
+++ b/mapping-io-extras/src/test/java/net/fabricmc/mappingio/extras/MappingTreeRemapperTest.java
@@ -16,9 +16,9 @@
 
 package net.fabricmc.mappingio.extras;
 
+import static net.fabricmc.mappingio.test.TestUtil.createTree;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static net.fabricmc.mappingio.test.TestUtil.createTree;
 
 import java.io.IOException;
 

--- a/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
@@ -100,12 +100,73 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 			classesByDstNames[i] = new HashMap<>(classesBySrcName.size());
 		}
 
+		Map<Integer, Map<String, Set<ClassEntry>>> duplicatesByNameByNs = null;
+
 		for (ClassEntry cls : classesBySrcName.values()) {
 			for (int i = 0; i < cls.dstNames.length; i++) {
 				String dstName = cls.dstNames[i];
-				if (dstName != null) classesByDstNames[i].put(dstName, cls);
+
+				if (dstName == null) {
+					continue;
+				}
+
+				ClassEntry prev = classesByDstNames[i].put(dstName, cls);
+
+				if (inDebugMode && prev != null) {
+					if (duplicatesByNameByNs == null) {
+						duplicatesByNameByNs = new LinkedHashMap<>();
+					}
+
+					Map<String, Set<ClassEntry>> duplicatesByName = duplicatesByNameByNs.computeIfAbsent(i, k -> new HashMap<>());
+					Set<ClassEntry> duplicates = duplicatesByName.computeIfAbsent(dstName, k -> new HashSet<>());
+					duplicates.add(prev);
+					duplicates.add(cls);
+				}
 			}
 		}
+
+		if (duplicatesByNameByNs != null) {
+			StringBuilder errorBuilder = new StringBuilder("Found destination names occurring multiple times per namespace:");
+
+			for (Map.Entry<Integer, Map<String, Set<ClassEntry>>> duplicateByNs : duplicatesByNameByNs.entrySet()) {
+				int ns = duplicateByNs.getKey();
+				Map<String, Set<ClassEntry>> duplicatesByName = duplicateByNs.getValue();
+
+				for (Map.Entry<String, Set<ClassEntry>> duplicate : duplicatesByName.entrySet()) {
+					String name = duplicate.getKey();
+					Set<ClassEntry> duplicates = duplicate.getValue();
+
+					errorBuilder.append("\n- \"")
+							.append(name)
+							.append("\" in namespace ")
+							.append(getNamespaceName(ns))
+							.append(" for classes ")
+							.append(duplicates.stream()
+									.map(ClassEntry::getSrcName)
+									.collect(Collectors.joining(", ")));
+				}
+			}
+
+			throw new IllegalStateException(errorBuilder.append("\nContinuing to use this tree may lead to unexpected behavior.").toString());
+		}
+	}
+
+	public boolean doesIndexByDstNames() {
+		return indexByDstNames;
+	}
+
+	/**
+	 * Whether additional assertions and safety checks should be enabled
+	 * at the expense of performance. Mostly useful for debugging.
+	 */
+	@ApiStatus.Internal
+	public void setInDebugMode(boolean inDebugMode) {
+		this.inDebugMode = inDebugMode;
+	}
+
+	@ApiStatus.Internal
+	public boolean isInDebugMode() {
+		return inDebugMode;
 	}
 
 	@ApiStatus.Experimental
@@ -301,7 +362,13 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		if (namespace < 0 || !indexByDstNames) {
 			return VisitableMappingTree.super.getClass(name, namespace);
 		} else {
-			return classesByDstNames[namespace].get(name);
+			ClassMapping ret = classesByDstNames[namespace].get(name);
+
+			if (inDebugMode && ret != VisitableMappingTree.super.getClass(name, namespace)) {
+				throw new IllegalStateException("Class name \"" + name + "\" in destination namespace " + getNamespaceName(namespace) + " is not unique");
+			}
+
+			return ret;
 		}
 	}
 
@@ -309,6 +376,52 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 	public ClassMapping addClass(ClassMapping cls) {
 		assertNotInVisitPass();
 		ClassEntry entry = cls instanceof ClassEntry && cls.getTree() == this ? (ClassEntry) cls : new ClassEntry(this, cls, getSrcNsEquivalent(cls));
+
+		if (inDebugMode) {
+			ClassEntry[] duplicates = null;
+
+			for (int i = 0; i < entry.dstNames.length; i++) {
+				String dstName = entry.dstNames[i];
+
+				if (dstName == null) {
+					continue;
+				}
+
+				ClassEntry existing = (ClassEntry) getClass(dstName, i);
+
+				if (existing != null) {
+					if (duplicates == null) {
+						duplicates = new ClassEntry[entry.dstNames.length];
+					}
+
+					duplicates[i] = existing;
+				}
+			}
+
+			if (duplicates != null) {
+				StringBuilder errorBuilder = new StringBuilder("Can't add \"")
+						.append(entry.getSrcName())
+						.append("\", some of its destination names are already assigned to other classes:");
+
+				for (int ns = 0; ns < duplicates.length; ns++) {
+					ClassEntry prev = duplicates[ns];
+
+					if (prev == null) {
+						continue;
+					}
+
+					errorBuilder.append("\n- \"")
+							.append(entry.dstNames[ns])
+							.append("\" in namespace ")
+							.append(getNamespaceName(ns))
+							.append(" by ")
+							.append(prev.getSrcName());
+				}
+
+				throw new IllegalStateException(errorBuilder.toString());
+			}
+		}
+
 		ClassEntry ret = classesBySrcName.putIfAbsent(cls.getSrcName(), entry);
 
 		if (ret != null) {
@@ -984,6 +1097,17 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		protected Entry(MemoryMappingTree tree, ElementMapping src, int srcNsEquivalent) {
 			this(tree, src.getName(srcNsEquivalent));
 
+			if (!(this instanceof MemberEntry<?>)) {
+				constructorCopyFrom(src);
+			}
+		}
+
+		/**
+		 * Ideally we would just always do this in the constructor above,
+		 * but {@link MemberEntry#setDstNameInternal(String, int)} requires {@link MemberEntry#owner} to be set,
+		 * which is not possible due to the compiler forcing us to call the super constructor above first.
+		 */
+		protected final void constructorCopyFrom(ElementMapping src) {
 			for (int i = 0; i < dstNames.length; i++) {
 				int dstNsEquivalent = src.getTree().getNamespaceId(tree.dstNamespaces.get(i));
 
@@ -1116,6 +1240,13 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 			}
 		}
 
+		protected abstract String toString(boolean withOwners);
+
+		@Override
+		public final String toString() {
+			return toString(false);
+		}
+
 		private final boolean missingSrcNameAllowed = getKind().level > MappedElementKind.METHOD.level; // args and vars
 		protected final MemoryMappingTree tree;
 		private String srcName;
@@ -1152,7 +1283,32 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 
 		@Override
 		void setDstNameInternal(String name, int namespace) {
-			if (tree.indexByDstNames) {
+			if (tree.inDebugMode) {
+				ClassMapping existing = tree.getClass(name, namespace);
+
+				if (existing != null && existing != this) {
+					throw new IllegalArgumentException("Destination name \""
+							+ name + "\" in namespace " + tree.getNamespaceName(namespace)
+							+ " is already in use by " + existing.getSrcName());
+				}
+			}
+
+			updateIndexByDstNames(name, namespace);
+
+			super.setDstNameInternal(name, namespace);
+		}
+
+		private void updateIndexByDstNames() {
+			for (int ns = 0; ns < dstNames.length; ns++) {
+				updateIndexByDstNames(dstNames[ns], ns);
+			}
+		}
+
+		private void updateIndexByDstNames(String name, int namespace) {
+			if (!tree.indexByDstNames || tree.getClass(getSrcNameUnchecked()) != this /* pending */) {
+				return;
+			}
+
 				String oldName = dstNames[namespace];
 
 				if (!Objects.equals(name, oldName)) {
@@ -1165,9 +1321,6 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 						map.remove(oldName);
 					}
 				}
-			}
-
-			super.setDstNameInternal(name, namespace);
 		}
 
 		@Override
@@ -1324,6 +1477,53 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		private <T extends MemberEntry<T>> T addMember(T entry, Map<MemberKey, T> map, int flagHasAny, int flagMissesAny) {
+			if (tree.inDebugMode) {
+				MemberEntry<?>[] duplicates = null;
+
+				for (int ns = 0; ns < entry.dstNames.length; ns++) {
+					String dstName = entry.getDstName(ns);
+
+					if (dstName == null) {
+						continue;
+					}
+
+					MemberEntry<?> existing = entry.getKind() == MappedElementKind.FIELD
+							? getField(dstName, entry.getDstDesc(ns), ns)
+							: getMethod(dstName, entry.getDstDesc(ns), ns);
+
+					if (existing != null) {
+						if (duplicates == null) {
+							duplicates = new MemberEntry<?>[entry.dstNames.length];
+						}
+
+						duplicates[ns] = existing;
+					}
+				}
+
+				if (duplicates != null) {
+					StringBuilder errorBuilder = new StringBuilder("Can't add")
+							.append(entry.toString(true))
+							.append(", some of its destination names are already assigned to other entries:");
+
+					for (int ns = 0; ns < duplicates.length; ns++) {
+						MemberEntry<?> prev = duplicates[ns];
+
+						if (prev == null) {
+							continue;
+						}
+
+						errorBuilder.append("\n- \"")
+								.append(entry.dstNames[ns])
+								.append("\" in namespace ")
+								.append(tree.getNamespaceName(ns))
+								.append(" by ")
+								.append(prev.getSrcName());
+					}
+
+					throw new IllegalStateException(errorBuilder.toString());
+				}
+			}
+
 			T ret = map.putIfAbsent(entry.getKey(), entry);
 
 			if (ret != null) { // same desc
@@ -1436,7 +1636,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
-		public String toString() {
+		protected String toString(boolean withOwners) {
 			return getSrcNameUnchecked();
 		}
 
@@ -1467,6 +1667,8 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 			this.owner = owner;
 			this.srcDesc = src.getDesc(srcNsEquivalent);
 			this.key = new MemberKey(getSrcName(), srcDesc);
+
+			constructorCopyFrom(src);
 		}
 
 		@Override
@@ -1500,6 +1702,21 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 
 		abstract void setSrcDescInternal(@Nullable String desc);
 
+		@Override
+		void setDstNameInternal(String name, int namespace) {
+			if (tree.inDebugMode) {
+				MemberEntry<?> existing = getKind() == MappedElementKind.FIELD
+						? owner.getField(name, getDesc(namespace), namespace)
+						: owner.getMethod(name, getDesc(namespace), namespace);
+
+				if (existing != null && existing != this) {
+					throw new IllegalArgumentException("Destination name \"" + name + "\" in namespace " + tree.getNamespaceName(namespace) + " is already in use by " + existing.toString(true));
+				}
+			}
+
+			super.setDstNameInternal(name, namespace);
+		}
+
 		MemberKey getKey() {
 			assertSrcNamePresent();
 			return key;
@@ -1524,6 +1741,19 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 			}
 
 			return acceptElement(visitor, dstDescs);
+		}
+
+		protected String toString(boolean completeHierarchy) {
+			String toFormat = getKind() == MappedElementKind.FIELD
+					? "%s:%s"
+					: "%s%s";
+			String ret = String.format(toFormat, getSrcNameUnchecked(), srcDesc);
+
+			if (completeHierarchy) {
+				ret = String.format("%s.%s", owner.toString(true), ret);
+			}
+
+			return ret;
 		}
 
 		protected ClassEntry owner;
@@ -1558,7 +1788,10 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 			MemberKey newKey = new MemberKey(getSrcName(), desc);
 
 			if (owner.fields != null) { // pending member
-				if (owner.fields.containsKey(newKey)) throw new IllegalArgumentException("conflicting name+desc after changing desc to "+desc+" for "+this);
+				if (owner.fields.containsKey(newKey)) {
+					throw new IllegalArgumentException("conflicting name+desc after changing desc to "+desc+" for "+toString(true)+", skipping");
+				}
+
 				owner.fields.remove(getKey());
 			}
 
@@ -1580,11 +1813,6 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 			if (visitor.visitField(getSrcName(), srcDesc)) {
 				acceptMember(visitor, supplyDstDescs);
 			}
-		}
-
-		@Override
-		public String toString() {
-			return String.format("%s;;%s", getSrcNameUnchecked(), srcDesc);
 		}
 	}
 
@@ -1881,11 +2109,6 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 			}
 		}
 
-		@Override
-		public String toString() {
-			return String.format("%s%s", getSrcNameUnchecked(), srcDesc);
-		}
-
 		private List<MethodArgEntry> args = null;
 		private List<MethodVarEntry> vars = null;
 		private List<MethodArgEntry> argsView = null;
@@ -1978,8 +2201,14 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
-		public String toString() {
-			return String.format("%d/%d:%s", argPosition, lvIndex, getSrcName());
+		protected String toString(boolean withOwners) {
+			String ret = String.format("%s:%d/%d", getSrcName(), argPosition, lvIndex);
+
+			if (withOwners) {
+				ret = String.format("%s.%s", method.toString(true), ret);
+			}
+
+			return ret;
 		}
 
 		private final MethodEntry method;
@@ -2089,8 +2318,14 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		@Override
-		public String toString() {
-			return String.format("%d/%d@%d-%d:%s", lvtRowIndex, lvIndex, startOpIdx, endOpIdx, getSrcName());
+		protected String toString(boolean withOwners) {
+			String ret = String.format("%s:%d/%d@%d-%d", getSrcName(), lvtRowIndex, lvIndex, startOpIdx, endOpIdx);
+
+			if (withOwners) {
+				ret = String.format("%s.%s", method.toString(true), ret);
+			}
+
+			return ret;
 		}
 
 		private final MethodEntry method;
@@ -2231,17 +2466,21 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		private final boolean isField;
 	}
 
-	private boolean inVisitPass;
+	// --- Configuration ---
 	private boolean indexByDstNames;
+	private boolean inDebugMode;
+
+	// --- Internal state ---
+	private boolean inVisitPass;
 	private String srcNamespace;
 	private List<String> dstNamespaces = Collections.emptyList();
 	private final List<MetadataEntry> metadata = new ArrayList<>();
 	private final Map<String, ClassEntry> classesBySrcName = new LinkedHashMap<>();
 	private final Collection<ClassEntry> classesView = Collections.unmodifiableCollection(classesBySrcName.values());
 	private Map<String, ClassEntry>[] classesByDstNames;
-
 	private HierarchyInfoProvider<?> hierarchyInfo;
 
+	// --- Current visit pass ---
 	/** The incoming source namespace's namespace index on the tree side. */
 	private int srcNsMap;
 	/** Incoming destination namespaces' namespace indices on the tree side. dstNameMap[incomingNsIdx] = treeSideNsIdx. */

--- a/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
@@ -136,13 +136,13 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 					String name = duplicate.getKey();
 					Set<ClassEntry> duplicates = duplicate.getValue();
 
-					errorBuilder.append("\n- \"")
+					errorBuilder.append("\n  - \"")
 							.append(name)
 							.append("\" in namespace ")
 							.append(getNamespaceName(ns))
 							.append(" for classes ")
 							.append(duplicates.stream()
-									.map(ClassEntry::getSrcName)
+									.map(ClassEntry::toString)
 									.collect(Collectors.joining(", ")));
 				}
 			}
@@ -153,6 +153,14 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 
 	public boolean doesIndexByDstNames() {
 		return indexByDstNames;
+	}
+
+	public void setSrcNameDevoidEntryMergingStrategy(SrcNameDevoidEntryMergingStrategy strategy) {
+		this.srcNameDevoidEntryMergingStrategy = strategy;
+	}
+
+	public SrcNameDevoidEntryMergingStrategy getSrcNameDevoidEntryMergingStrategy() {
+		return srcNameDevoidEntryMergingStrategy;
 	}
 
 	/**
@@ -365,8 +373,14 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		} else {
 			ClassMapping ret = classesByDstNames[namespace].get(name);
 
-			if (inDebugMode && ret != VisitableMappingTree.super.getClass(name, namespace)) {
-				throw new IllegalStateException("Class name \"" + name + "\" in destination namespace " + getNamespaceName(namespace) + " is not unique");
+			if (inDebugMode) {
+				ClassMapping expected = VisitableMappingTree.super.getClass(name, namespace);
+
+				if (ret != expected) {
+					throw new IllegalStateException("Class name \"" + name
+							+ "\" in destination namespace " + getNamespaceName(namespace) + " is not unique: "
+							+ ret + " conflicts with at least " + expected);
+				}
 			}
 
 			return ret;
@@ -401,7 +415,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 
 			if (duplicates != null) {
 				StringBuilder errorBuilder = new StringBuilder("Can't add \"")
-						.append(entry.getSrcName())
+						.append(entry.toString(true))
 						.append("\", some of its destination names are already assigned to other classes:");
 
 				for (int ns = 0; ns < duplicates.length; ns++) {
@@ -411,12 +425,13 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 						continue;
 					}
 
-					errorBuilder.append("\n- \"")
+					errorBuilder.append("\n  - \"")
 							.append(entry.dstNames[ns])
-							.append("\" in namespace ")
+							.append("\" in namespace \"")
 							.append(getNamespaceName(ns))
-							.append(" by ")
-							.append(prev.getSrcName());
+							.append("\" by \"")
+							.append(prev.toString(false))
+							.append("\"");
 				}
 
 				throw new IllegalStateException(errorBuilder.toString());
@@ -738,6 +753,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 
 	private void addPendingClass(ClassEntry cls) {
 		int startIdx = cls.isSrcNameMissing() ? 0 : SRC_NAMESPACE_ID;
+		Set<ClassEntry> matches = null;
 
 		for (int i = startIdx; i <= dstNameMap.length; i++) {
 			int ns = i;
@@ -765,18 +781,55 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 			ClassEntry existing = (ClassEntry) getClass(name, ns);
 
 			if (existing != null) {
-				existing.copyFrom(cls, true);
+				if (srcNameDevoidEntryMergingStrategy == SrcNameDevoidEntryMergingStrategy.FIRST_MATCH) {
+					matches = Collections.singleton(existing);
+					break;
+				} else {
+					if (matches == null) {
+						matches = Collections.newSetFromMap(new LinkedHashMap<>());
+					}
 
-				if (cls.isSrcNameMissing()) {
-					// Copy source name so cls's pending members can be processed later on
-					cls.setSrcName(existing.getSrcName());
+					matches.add(existing);
 				}
-
-				break; // this ignores potential matches with other namespaces, but at that point it's the user's fault for being too ambiguous
 			} else if (ns == SRC_NAMESPACE_ID) {
 				classesBySrcName.put(name, cls);
-				break;
+				cls.updateIndexByDstNames();
+				return;
 			}
+		}
+
+		if (matches == null) {
+			return;
+		}
+
+		if (matches.size() > 1 && srcNameDevoidEntryMergingStrategy == SrcNameDevoidEntryMergingStrategy.REJECT_AMBIGUOUS) {
+			// TODO: Add a way to report this to the user (PR 94?)
+
+			if (inDebugMode) {
+				throw new IllegalStateException("Found multiple matches for " + cls.toString(true));
+			}
+
+			return;
+		}
+
+		ClassEntry latestSubmittedMatch = null;
+
+		for (ClassEntry treeCls : classesBySrcName.values()) {
+			if (matches.contains(treeCls)) {
+				latestSubmittedMatch = treeCls;
+			}
+		}
+
+		matches.remove(latestSubmittedMatch);
+		matches.add(cls);
+
+		for (ClassEntry match : matches) {
+			latestSubmittedMatch.copyFrom(match, true);
+		}
+
+		if (cls.isSrcNameMissing()) {
+			// Copy source name so cls's pending members can be processed later on
+			cls.setSrcName(latestSubmittedMatch.getSrcName());
 		}
 	}
 
@@ -792,8 +845,10 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		boolean isField = member.getKind() == MappedElementKind.FIELD;
 		int startIdx = member.isSrcNameMissing() && member.getSrcDesc() == null ? 0 : SRC_NAMESPACE_ID;
 		Map.Entry<Integer, String> anyDesc = null;
+		Set<MemberEntry<?>> matches = null;
 		int findDescPhase = 0;
 		int addToTreePhase = 1;
+		String srcDesc = null;
 
 		for (int phase = findDescPhase; phase <= addToTreePhase; phase++) {
 			for (int i = startIdx; i <= dstNameMap.length; i++) {
@@ -840,37 +895,85 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 					desc = mapDesc(anyDesc.getValue(), anyDesc.getKey(), ns);
 				}
 
+				if (ns == SRC_NAMESPACE_ID) {
+					assert srcDesc == null;
+					srcDesc = desc;
+				}
+
 				MemberEntry<?> existing = isField
 						? owner.getField(name, desc, ns)
 						: owner.getMethod(name, desc, ns);
 
-				if (ns != SRC_NAMESPACE_ID && existing == null) {
-					continue;
-				}
-
-				if (member.getSrcDesc() == null && desc != null && (existing == null || existing.getSrcDesc() == null)) {
-					member.setSrcDescInternal(mapDesc(desc, ns, SRC_NAMESPACE_ID));
-				}
-
 				if (existing != null) {
-					assert member.srcDesc == null || existing.srcDesc == null || member.srcDesc.equals(existing.srcDesc);
-
-					if (isField) {
-						((FieldEntry) existing).copyFrom((FieldEntry) member, true);
+					if (srcNameDevoidEntryMergingStrategy == SrcNameDevoidEntryMergingStrategy.FIRST_MATCH) {
+						matches = Collections.singleton(existing);
+						break;
 					} else {
-						((MethodEntry) existing).copyFrom((MethodEntry) member, true);
+						if (matches == null) {
+							matches = Collections.newSetFromMap(new LinkedHashMap<>());
+						}
+
+						matches.add(existing);
+					}
+				} else if (ns == SRC_NAMESPACE_ID) {
+					if (member.getSrcDesc() == null && srcDesc != null) {
+						member.setSrcDescInternal(srcDesc);
 					}
 
-					break; // this ignores potential matches with other namespaces, but at that point it's the user's fault for being too ambiguous
-				} else { // ns == SRC_NAMESPACE_ID
 					if (isField) {
 						owner.addFieldInternal((FieldEntry) member);
 					} else {
 						owner.addMethodInternal((MethodEntry) member);
 					}
 
-					break;
+					return;
 				}
+			}
+		}
+
+		if (matches == null) {
+			return;
+		}
+
+		if (matches.size() > 1 && srcNameDevoidEntryMergingStrategy == SrcNameDevoidEntryMergingStrategy.REJECT_AMBIGUOUS) {
+			// TODO: Add a way to report this to the user (PR 94?)
+
+			if (inDebugMode) {
+				throw new IllegalStateException("Found multiple matches for " + member.toString(true) + " in " + member.getOwner().toString(true));
+			}
+
+			return;
+		}
+
+		MemberEntry<?> latestSubmittedMatch = null;
+		Collection<? extends MemberEntry<?>> treeMembers = isField
+				? owner.getFields()
+				: owner.getMethods();
+
+		for (MemberEntry<?> treeMember : treeMembers) {
+			if (matches.contains(treeMember)) {
+				latestSubmittedMatch = treeMember;
+			}
+		}
+
+		matches.remove(latestSubmittedMatch);
+		matches.add(member);
+
+		for (MemberEntry<?> match : matches) {
+			if (isField) {
+				((FieldEntry) latestSubmittedMatch).copyFrom((FieldEntry) match, true);
+			} else {
+				((MethodEntry) latestSubmittedMatch).copyFrom((MethodEntry) match, true);
+			}
+		}
+
+		if (latestSubmittedMatch.getSrcDesc() == null) {
+			if (srcDesc == null && anyDesc != null) {
+				srcDesc = mapDesc(anyDesc.getValue(), anyDesc.getKey(), SRC_NAMESPACE_ID);
+			}
+
+			if (srcDesc != null) {
+				latestSubmittedMatch.setSrcDescInternal(srcDesc);
 			}
 		}
 	}
@@ -1088,6 +1191,32 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 	}
 
+	/**
+	 * Strategy for merging incoming entries which don't supply a name for the tree-side source namespace,
+	 * but do supply a name for a tree-side destination namespace,
+	 * which might already be in use by an existing entry (= match).
+	 */
+	public enum SrcNameDevoidEntryMergingStrategy {
+		/**
+		 * Pending data will be merged into the first matching entry,
+		 * there will be no checks if further matches might exist.
+		 */
+		FIRST_MATCH,
+
+		/**
+		 * Checks if multiple matches exist. If not, same as {@link #FIRST_MATCH},
+		 * otherwise merges all matching entries into the last submitted entry,
+		 * merges pending data into there and then deletes the other matches from the tree.
+		 */
+		ALL_MATCHES,
+
+		/**
+		 * Checks if multiple matches exist. If not, same as {@link #FIRST_MATCH},
+		 * otherwise ignores the pending data.
+		 */
+		REJECT_AMBIGUOUS
+	}
+
 	abstract static class Entry<T extends Entry<T>> implements ElementMapping {
 		protected Entry(MemoryMappingTree tree, String srcName) {
 			this.tree = tree;
@@ -1232,7 +1361,13 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		protected void copyFrom(T o, boolean replace) {
 			for (int i = 0; i < dstNames.length; i++) {
 				if (o.dstNames[i] != null && (replace || dstNames[i] == null)) {
-					dstNames[i] = o.dstNames[i];
+					String oDstName = o.dstNames[i];
+
+					if (this instanceof ClassEntry) {
+						((ClassEntry) this).updateIndexByDstNames(oDstName, i, false);
+					}
+
+					dstNames[i] = oDstName;
 				}
 			}
 
@@ -1287,32 +1422,34 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 			if (tree.inDebugMode) {
 				ClassMapping existing = tree.getClass(name, namespace);
 
-				if (existing != null && existing != this) {
+				if (existing != null && existing != this && getSrcNameUnchecked() != null) {
 					throw new IllegalArgumentException("Destination name \""
 							+ name + "\" in namespace " + tree.getNamespaceName(namespace)
-							+ " is already in use by " + existing.getSrcName());
+							+ " in the process to be set for class " + toString()
+							+ " is already in use by " + existing.toString()
+							+ ", aborting");
 				}
 			}
 
-			updateIndexByDstNames(name, namespace);
+			updateIndexByDstNames(name, namespace, false);
 
 			super.setDstNameInternal(name, namespace);
 		}
 
 		private void updateIndexByDstNames() {
 			for (int ns = 0; ns < dstNames.length; ns++) {
-				updateIndexByDstNames(dstNames[ns], ns);
+				updateIndexByDstNames(dstNames[ns], ns, true);
 			}
 		}
 
-		private void updateIndexByDstNames(String name, int namespace) {
+		private void updateIndexByDstNames(String name, int namespace, boolean skipEqualityCheck) {
 			if (!tree.indexByDstNames || tree.getClass(getSrcNameUnchecked()) != this /* pending */) {
 				return;
 			}
 
 			String oldName = dstNames[namespace];
 
-			if (!Objects.equals(name, oldName)) {
+			if (skipEqualityCheck || !Objects.equals(name, oldName)) {
 				Map<String, ClassEntry> map = tree.classesByDstNames[namespace];
 				if (oldName != null) map.remove(oldName);
 
@@ -1478,6 +1615,32 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		private <T extends MemberEntry<T>> T addMember(T entry, Map<MemberKey, T> map, int flagHasAny, int flagMissesAny) {
+			T existing = map.get(entry.getKey());
+			T existingDescless = null;
+			T existingDescContaining = null;
+			boolean validDesc = false;
+			MemberKey existingDesclessKey = null;
+			byte flags = this.flags;
+
+			if (existing == null) {
+				if (isValidDescriptor(entry.srcDesc, true)) { // entry has desc, check for desc-less match
+					validDesc = true;
+					flags |= flagHasAny;
+
+					if ((flags & flagMissesAny) != 0) {
+						existingDesclessKey = new MemberKey(entry.getSrcName(), null);
+						existingDescless = map.get(existingDesclessKey);
+					}
+				} else if ((flags & flagHasAny) != 0) { // entry has no desc, check for desc-containing match
+					for (T mapEntry : map.values()) {
+						if (mapEntry != entry && mapEntry.getSrcName().equals(entry.getSrcName()) && (entry.srcDesc == null || mapEntry.srcDesc.startsWith(entry.srcDesc))) {
+							existingDescContaining = mapEntry;
+							break;
+						}
+					}
+				}
+			}
+
 			if (tree.inDebugMode) {
 				MemberEntry<?>[] duplicates = null;
 
@@ -1488,23 +1651,23 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 						continue;
 					}
 
-					MemberEntry<?> existing = entry.getKind() == MappedElementKind.FIELD
+					MemberEntry<?> match = entry.getKind() == MappedElementKind.FIELD
 							? getField(dstName, entry.getDstDesc(ns), ns)
 							: getMethod(dstName, entry.getDstDesc(ns), ns);
 
-					if (existing != null) {
+					if (match != existing && match != existingDescless && match != existingDescContaining) {
 						if (duplicates == null) {
 							duplicates = new MemberEntry<?>[entry.dstNames.length];
 						}
 
-						duplicates[ns] = existing;
+						duplicates[ns] = match;
 					}
 				}
 
 				if (duplicates != null) {
-					StringBuilder errorBuilder = new StringBuilder("Can't add")
+					StringBuilder errorBuilder = new StringBuilder("Can't add \"")
 							.append(entry.toString(true))
-							.append(", some of its destination names are already assigned to other entries:");
+							.append("\", some of its destination names are already assigned to other entries:");
 
 					for (int ns = 0; ns < duplicates.length; ns++) {
 						MemberEntry<?> prev = duplicates[ns];
@@ -1513,55 +1676,55 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 							continue;
 						}
 
-						errorBuilder.append("\n- \"")
+						errorBuilder.append("\n  - \"")
 								.append(entry.dstNames[ns])
-								.append("\" in namespace ")
+								.append("\" in namespace \"")
 								.append(tree.getNamespaceName(ns))
-								.append(" by ")
-								.append(prev.getSrcName());
+								.append("\" by \"")
+								.append(prev.toString(false))
+								.append("\"");
 					}
 
 					throw new IllegalStateException(errorBuilder.toString());
 				}
 			}
 
-			T ret = map.putIfAbsent(entry.getKey(), entry);
+			if (existing != null) { // same desc
+				existing.copyFrom(entry, true);
 
-			if (ret != null) { // same desc
-				ret.copyFrom(entry, true);
+				return existing;
+			} else {
+				T ret = entry;
 
+				if (validDesc) {
+					flags |= flagHasAny;
+
+					existing = map.put(entry.getKey(), entry);
+					assert existing == null;
+
+					if (existingDescless != null) { // compatible desc-less entry exists, copy desc + extra content
+						assert existingDesclessKey != null;
+
+						map.remove(existingDesclessKey);
+
+						existingDescless.copyFrom(entry, true);
+						ret = existingDescless;
+					}
+				} else {
+					if (existingDescContaining != null) {
+						existingDescContaining.copyFrom(entry, true);
+
+						ret = existingDescContaining;
+					} else {
+						existing = map.put(entry.getKey(), entry);
+						assert existing == null;
+					}
+
+					flags |= flagMissesAny;
+				}
+
+				this.flags = flags;
 				return ret;
-			} else if (isValidDescriptor(entry.srcDesc, true)) { // may have replaced desc-less
-				flags |= flagHasAny;
-
-				if ((flags & flagMissesAny) != 0) {
-					ret = map.remove(new MemberKey(entry.getSrcName(), null));
-
-					if (ret != null) { // compatible entry exists, copy desc + extra content
-						ret.setKey(entry.getKey());
-						ret.srcDesc = entry.srcDesc;
-						map.put(ret.getKey(), ret);
-						ret.copyFrom(entry, true);
-						entry = ret;
-					}
-				}
-
-				return entry;
-			} else { // entry.srcDesc == null, may have replaced desc-containing
-				if ((flags & flagHasAny) != 0) {
-					for (T prevEntry : map.values()) {
-						if (prevEntry != entry && prevEntry.getSrcName().equals(entry.getSrcName()) && (entry.srcDesc == null || prevEntry.srcDesc.startsWith(entry.srcDesc))) {
-							map.remove(entry.getKey());
-							prevEntry.copyFrom(entry, true);
-
-							return prevEntry;
-						}
-					}
-				}
-
-				flags |= flagMissesAny;
-
-				return entry;
 			}
 		}
 
@@ -2469,6 +2632,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 
 	// --- Configuration ---
 	private boolean indexByDstNames;
+	private SrcNameDevoidEntryMergingStrategy srcNameDevoidEntryMergingStrategy = SrcNameDevoidEntryMergingStrategy.ALL_MATCHES;
 	private boolean inDebugMode;
 
 	// --- Internal state ---

--- a/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
@@ -157,7 +157,8 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 
 	/**
 	 * Whether additional assertions and safety checks should be enabled
-	 * at the expense of performance. Mostly useful for debugging.
+	 * at the expense of performance. Useful for debugging or input
+	 * data validation.
 	 */
 	@ApiStatus.Internal
 	public void setInDebugMode(boolean inDebugMode) {
@@ -1309,18 +1310,18 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 				return;
 			}
 
-				String oldName = dstNames[namespace];
+			String oldName = dstNames[namespace];
 
-				if (!Objects.equals(name, oldName)) {
-					Map<String, ClassEntry> map = tree.classesByDstNames[namespace];
-					if (oldName != null) map.remove(oldName);
+			if (!Objects.equals(name, oldName)) {
+				Map<String, ClassEntry> map = tree.classesByDstNames[namespace];
+				if (oldName != null) map.remove(oldName);
 
-					if (name != null) {
-						map.put(name, this);
-					} else {
-						map.remove(oldName);
-					}
+				if (name != null) {
+					map.put(name, this);
+				} else {
+					map.remove(oldName);
 				}
+			}
 		}
 
 		@Override

--- a/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
@@ -633,18 +633,16 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 					ns = srcNsMap;
 
 					if (disassociatedSourceNs) {
-						continue; // no existing names can be found here, ns didn't exist before this pass
+						continue; // no existing entries' names can be found here, ns didn't exist before this pass
 					}
 				} else {
 					ns = dstNameMap[ns - 1];
 				}
-
-				if (ns == SRC_NAMESPACE_ID && cls.isSrcNameMissing()) {
-					continue;
-				}
 			}
 
-			String name = cls.getName(ns);
+			String name = ns == SRC_NAMESPACE_ID
+					? cls.getSrcNameUnchecked()
+					: cls.getDstName(ns);
 
 			if (name == null) {
 				continue;
@@ -678,7 +676,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		member.setOwner(owner);
 
 		boolean isField = member.getKind() == MappedElementKind.FIELD;
-		int startIdx = member.isSrcNameMissing() ? 0 : SRC_NAMESPACE_ID;
+		int startIdx = member.isSrcNameMissing() && member.getSrcDesc() == null ? 0 : SRC_NAMESPACE_ID;
 		Map.Entry<Integer, String> anyDesc = null;
 		int findDescPhase = 0;
 		int addToTreePhase = 1;
@@ -692,14 +690,14 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 						ns = srcNsMap;
 
 						if (disassociatedSourceNs && phase != findDescPhase) {
-							continue; // no existing names can be found here, ns didn't exist before this pass
+							continue; // no existing entries' names can be found here, ns didn't exist before this pass
 						}
 					} else {
 						ns = dstNameMap[ns - 1];
 					}
 
-					if (ns == SRC_NAMESPACE_ID && member.isSrcNameMissing()) {
-						continue;
+					if (ns == SRC_NAMESPACE_ID && startIdx == SRC_NAMESPACE_ID) {
+						continue; // already checked in the first iteration
 					}
 				}
 
@@ -716,7 +714,9 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 					continue;
 				}
 
-				String name = member.getName(ns);
+				String name = ns == SRC_NAMESPACE_ID
+						? member.getSrcNameUnchecked()
+						: member.getDstName(ns);
 
 				if (name == null) {
 					continue;

--- a/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
@@ -17,6 +17,7 @@
 package net.fabricmc.mappingio.tree;
 
 import java.io.IOException;
+import java.util.AbstractMap;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -394,17 +395,19 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		inVisitPass = false;
 		srcNsMap = SRC_NAMESPACE_ID;
 		dstNameMap = null;
+		disassociatedSourceNs = false;
 		currentEntry = null;
 		currentClass = null;
 		currentMethod = null;
 		pendingClasses = null;
 		pendingMembers = null;
+		pendingMemberDescs = null;
 	}
 
 	@Override
 	public void visitNamespaces(String srcNamespace, List<String> dstNamespaces) {
+		reset(); // Just in case we never reached visitEnd in the previous pass due to an unexpected exception
 		inVisitPass = true;
-		srcNsMap = SRC_NAMESPACE_ID;
 		dstNameMap = new int[dstNamespaces.size()];
 
 		if (this.srcNamespace != null) { // ns already set, try to merge
@@ -412,12 +415,13 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 				srcNsMap = this.dstNamespaces.indexOf(srcNamespace);
 
 				if (srcNsMap < 0) {
-					reset();
-					throw new IllegalArgumentException("can't merge with disassociated src namespace"); // srcNamespace must already be present
+					disassociatedSourceNs = true;
+					srcNsMap = NULL_NAMESPACE_ID;
 				}
 			}
 
 			int newDstNamespaces = 0;
+			List<String> treeSideDstNamespaces = this.dstNamespaces;
 
 			for (int i = 0; i < dstNameMap.length; i++) {
 				String dstNs = dstNamespaces.get(i);
@@ -429,19 +433,38 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 					reset();
 					throw new IllegalArgumentException("namespace \"" + srcNamespace + "\" is present on both source and destination side simultaneously");
 				} else {
-					idx = this.dstNamespaces.indexOf(dstNs);
+					idx = treeSideDstNamespaces.indexOf(dstNs);
 
 					if (idx < 0) {
-						if (newDstNamespaces == 0) this.dstNamespaces = new ArrayList<>(this.dstNamespaces);
+						if (newDstNamespaces == 0) {
+							treeSideDstNamespaces = new ArrayList<>(treeSideDstNamespaces);
+						}
 
-						idx = this.dstNamespaces.size();
-						this.dstNamespaces.add(dstNs);
+						idx = treeSideDstNamespaces.size();
+						treeSideDstNamespaces.add(dstNs);
 						newDstNamespaces++;
 					}
 				}
 
 				dstNameMap[i] = idx;
 			}
+
+			if (disassociatedSourceNs) {
+				if (newDstNamespaces == dstNameMap.length) {
+					reset();
+					throw new IllegalArgumentException("none of the incoming namespaces are present in the tree, can't merge");
+				}
+
+				if (newDstNamespaces == 0) {
+					treeSideDstNamespaces = new ArrayList<>(treeSideDstNamespaces);
+				}
+
+				srcNsMap = treeSideDstNamespaces.size();
+				treeSideDstNamespaces.add(srcNamespace);
+				newDstNamespaces++;
+			}
+
+			this.dstNamespaces = treeSideDstNamespaces;
 
 			if (newDstNamespaces > 0) {
 				int newSize = this.dstNamespaces.size();
@@ -557,6 +580,8 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 	}
 
 	private ClassEntry queuePendingClass(String name) {
+		assert srcNsMap >= 0;
+
 		if (pendingClasses == null) pendingClasses = new HashMap<>();
 		ClassEntry cls = pendingClasses.get(name);
 
@@ -565,84 +590,175 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 			pendingClasses.put(name, cls);
 		}
 
-		assert srcNsMap >= 0;
 		cls.setDstNameInternal(name, srcNsMap);
 
 		return cls;
 	}
 
 	private MemberEntry<?> queuePendingMember(String name, @Nullable String desc, boolean isField) {
-		if (pendingMembers == null) pendingMembers = new HashMap<>();
+		assert srcNsMap >= 0;
+
+		if (pendingMembers == null) {
+			pendingMembers = new HashMap<>();
+			pendingMemberDescs = new HashMap<>();
+		}
+
 		GlobalMemberKey key = new GlobalMemberKey(currentClass, name, desc, isField);
 		MemberEntry<?> member = pendingMembers.get(key);
 
 		if (member == null) {
 			if (isField) {
-				member = new FieldEntry(currentClass, null, desc); // we're misusing the srcDesc field to store the dstDesc (as there is no dstDesc field)
+				member = new FieldEntry(currentClass, null, null);
 			} else {
-				member = new MethodEntry(currentClass, null, desc);
+				member = new MethodEntry(currentClass, null, null);
 			}
 
 			pendingMembers.put(key, member);
+			pendingMemberDescs.computeIfAbsent(member, m -> new String[dstNamespaces.size()])[srcNsMap] = desc;
 		}
 
-		assert srcNsMap >= 0;
 		member.setDstNameInternal(name, srcNsMap);
 
 		return member;
 	}
 
 	private void addPendingClass(ClassEntry cls) {
-		if (cls.isSrcNameMissing()) {
-			return;
-		}
+		int startIdx = cls.isSrcNameMissing() ? 0 : SRC_NAMESPACE_ID;
+		int endIdx = disassociatedSourceNs ? dstNameMap.length - 1 : dstNameMap.length;
 
-		String srcName = cls.getSrcName();
-		ClassEntry existing = classesBySrcName.get(srcName);
+		for (int i = startIdx; i <= endIdx; i++) {
+			int ns = i;
 
-		if (existing == null) {
-			classesBySrcName.put(srcName, cls);
-		} else { // copy remaining data
-			existing.copyFrom(cls, true);
+			if (ns != SRC_NAMESPACE_ID) {
+				if (disassociatedSourceNs) {
+					ns = dstNameMap[ns];
+				} else {
+					if (ns == 0) {
+						ns = srcNsMap;
+					} else {
+						ns = dstNameMap[ns - 1];
+					}
+				}
+
+				if (ns == SRC_NAMESPACE_ID && cls.isSrcNameMissing()) {
+					continue;
+				}
+			}
+
+			String name = cls.getName(ns);
+
+			if (name == null) {
+				continue;
+			}
+
+			ClassEntry existing = (ClassEntry) getClass(name, ns);
+
+			if (existing != null) {
+				existing.copyFrom(cls, true);
+
+				if (cls.isSrcNameMissing()) {
+					// Copy source name so cls's pending members can be processed later on
+					cls.setSrcName(existing.getSrcName());
+				}
+
+				break; // this ignores potential matches with other namespaces, but at that point it's the user's fault for being too ambiguous
+			} else if (ns == SRC_NAMESPACE_ID) {
+				classesBySrcName.put(name, cls);
+				break;
+			}
 		}
 	}
 
 	private void addPendingMember(MemberEntry<?> member) {
-		if (member.isSrcNameMissing() || member.getOwner().isSrcNameMissing()) {
+		if (member.getOwner().isSrcNameMissing()) {
 			return;
 		}
 
 		// Make sure the owner reference is pointing to an in-tree entry
 		ClassEntry owner = classesBySrcName.get(member.getOwner().getSrcName());
 		member.setOwner(owner);
+
 		boolean isField = member.getKind() == MappedElementKind.FIELD;
-		String srcName = member.getSrcName();
-		String dstDesc = member.getSrcDesc(); // pending members' srcDesc is actually their dst desc
-		String srcDesc = null;
+		int startIdx = member.isSrcNameMissing() ? 0 : SRC_NAMESPACE_ID;
+		int endIdx = disassociatedSourceNs ? dstNameMap.length - 1 : dstNameMap.length;
+		Map.Entry<Integer, String> anyDesc = null;
+		int findDescPhase = 0;
+		int addToTreePhase = 1;
 
-		if (isValidDescriptor(dstDesc, !isField)) {
-			srcDesc = mapDesc(dstDesc, srcNsMap, SRC_NAMESPACE_ID);
-		}
+		for (int phase = findDescPhase; phase <= addToTreePhase; phase++) {
+			for (int i = startIdx; i <= endIdx; i++) {
+				int ns = i;
 
-		member.setSrcDescInternal(srcDesc);
+				if (ns != SRC_NAMESPACE_ID) {
+					if (disassociatedSourceNs) {
+						ns = dstNameMap[ns];
+					} else {
+						if (ns == 0) {
+							ns = srcNsMap;
+						} else {
+							ns = dstNameMap[ns - 1];
+						}
+					}
 
-		if (isField) {
-			FieldEntry queuedField = (FieldEntry) member;
-			FieldEntry existingField = owner.getField(srcName, srcDesc);
+					if (ns == SRC_NAMESPACE_ID && member.isSrcNameMissing()) {
+						continue;
+					}
+				}
 
-			if (existingField == null) {
-				owner.addFieldInternal(queuedField);
-			} else { // copy remaining data
-				existingField.copyFrom(queuedField, true);
-			}
-		} else {
-			MethodEntry queuedMethod = (MethodEntry) member;
-			MethodEntry existingMethod = owner.getMethod(srcName, srcDesc);
+				String desc = ns == SRC_NAMESPACE_ID
+						? member.getSrcDesc()
+						: pendingMemberDescs.get(member)[ns];
 
-			if (existingMethod == null) {
-				owner.addMethodInternal(queuedMethod);
-			} else { // copy remaining data
-				existingMethod.copyFrom(queuedMethod, true);
+				if (phase == findDescPhase) {
+					if (isValidDescriptor(desc, !isField)) {
+						anyDesc = new AbstractMap.SimpleEntry<>(ns, desc);
+						break;
+					}
+
+					continue;
+				}
+
+				String name = member.getName(ns);
+
+				if (name == null) {
+					continue;
+				}
+
+				if (desc == null && anyDesc != null) {
+					desc = mapDesc(anyDesc.getValue(), anyDesc.getKey(), ns);
+				}
+
+				MemberEntry<?> existing = isField
+						? owner.getField(name, desc, ns)
+						: owner.getMethod(name, desc, ns);
+
+				if (ns != SRC_NAMESPACE_ID && existing == null) {
+					continue;
+				}
+
+				if (member.getSrcDesc() == null && desc != null && (existing == null || existing.getSrcDesc() == null)) {
+					member.setSrcDescInternal(mapDesc(desc, ns, SRC_NAMESPACE_ID));
+				}
+
+				if (existing != null) {
+					assert member.srcDesc == null || existing.srcDesc == null || member.srcDesc.equals(existing.srcDesc);
+
+					if (isField) {
+						((FieldEntry) existing).copyFrom((FieldEntry) member, true);
+					} else {
+						((MethodEntry) existing).copyFrom((MethodEntry) member, true);
+					}
+
+					break; // this ignores potential matches with other namespaces, but at that point it's the user's fault for being too ambiguous
+				} else { // ns == SRC_NAMESPACE_ID
+					if (isField) {
+						owner.addFieldInternal((FieldEntry) member);
+					} else {
+						owner.addMethodInternal((MethodEntry) member);
+					}
+
+					break;
+				}
 			}
 		}
 	}
@@ -801,6 +917,25 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 			throw new UnsupportedOperationException("can't change src name for "+currentEntry.getKind());
 		} else {
 			currentEntry.setDstNameInternal(name, namespace);
+		}
+	}
+
+	@Override
+	public void visitDstDesc(MappedElementKind targetKind, int namespace, String desc) throws IOException {
+		namespace = dstNameMap[namespace];
+
+		if (currentEntry == null) throw new UnsupportedOperationException("Tried to visit mapped descriptor before owner");
+
+		MemberEntry<?> currentMember = (MemberEntry<?>) currentEntry;
+
+		if (pendingMemberDescs == null || !pendingMemberDescs.containsKey(currentMember)) {
+			return;
+		}
+
+		if (namespace < 0) {
+			currentMember.setSrcDescInternal(desc);
+		} else {
+			pendingMemberDescs.get(currentMember)[namespace] = desc;
 		}
 	}
 
@@ -2111,11 +2246,15 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 
 	/** The incoming source namespace's namespace index on the tree side. */
 	private int srcNsMap;
+	/** Incoming destination namespaces' namespace indices on the tree side. dstNameMap[incomingNsIdx] = treeSideNsIdx. */
 	private int[] dstNameMap;
+	/** Whether the incoming source namespace was not in the tree prior to the current visit pass. */
+	private boolean disassociatedSourceNs;
 	private Entry<?> currentEntry;
 	private ClassEntry currentClass;
 	private MethodEntry currentMethod;
 	/** originalSrcName -> clsEntry. */
 	private Map<String, ClassEntry> pendingClasses;
 	private Map<GlobalMemberKey, MemberEntry<?>> pendingMembers;
+	private Map<MemberEntry<?>, String[]> pendingMemberDescs;
 }

--- a/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
@@ -452,7 +452,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 			if (disassociatedSourceNs) {
 				if (newDstNamespaces == dstNameMap.length) {
 					reset();
-					throw new IllegalArgumentException("none of the incoming namespaces are present in the tree, can't merge");
+					throw new IllegalArgumentException("none of the incoming namespaces are present in the non-empty tree, can't merge");
 				}
 
 				if (newDstNamespaces == 0) {
@@ -624,20 +624,19 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 
 	private void addPendingClass(ClassEntry cls) {
 		int startIdx = cls.isSrcNameMissing() ? 0 : SRC_NAMESPACE_ID;
-		int endIdx = disassociatedSourceNs ? dstNameMap.length - 1 : dstNameMap.length;
 
-		for (int i = startIdx; i <= endIdx; i++) {
+		for (int i = startIdx; i <= dstNameMap.length; i++) {
 			int ns = i;
 
 			if (ns != SRC_NAMESPACE_ID) {
-				if (disassociatedSourceNs) {
-					ns = dstNameMap[ns];
-				} else {
-					if (ns == 0) {
-						ns = srcNsMap;
-					} else {
-						ns = dstNameMap[ns - 1];
+				if (ns == 0) {
+					ns = srcNsMap;
+
+					if (disassociatedSourceNs) {
+						continue; // no existing names can be found here, ns didn't exist before this pass
 					}
+				} else {
+					ns = dstNameMap[ns - 1];
 				}
 
 				if (ns == SRC_NAMESPACE_ID && cls.isSrcNameMissing()) {
@@ -680,24 +679,23 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 
 		boolean isField = member.getKind() == MappedElementKind.FIELD;
 		int startIdx = member.isSrcNameMissing() ? 0 : SRC_NAMESPACE_ID;
-		int endIdx = disassociatedSourceNs ? dstNameMap.length - 1 : dstNameMap.length;
 		Map.Entry<Integer, String> anyDesc = null;
 		int findDescPhase = 0;
 		int addToTreePhase = 1;
 
 		for (int phase = findDescPhase; phase <= addToTreePhase; phase++) {
-			for (int i = startIdx; i <= endIdx; i++) {
+			for (int i = startIdx; i <= dstNameMap.length; i++) {
 				int ns = i;
 
 				if (ns != SRC_NAMESPACE_ID) {
-					if (disassociatedSourceNs) {
-						ns = dstNameMap[ns];
-					} else {
-						if (ns == 0) {
-							ns = srcNsMap;
-						} else {
-							ns = dstNameMap[ns - 1];
+					if (ns == 0) {
+						ns = srcNsMap;
+
+						if (disassociatedSourceNs && phase != findDescPhase) {
+							continue; // no existing names can be found here, ns didn't exist before this pass
 						}
+					} else {
+						ns = dstNameMap[ns - 1];
 					}
 
 					if (ns == SRC_NAMESPACE_ID && member.isSrcNameMissing()) {

--- a/src/test/java/net/fabricmc/mappingio/test/TestUtil.java
+++ b/src/test/java/net/fabricmc/mappingio/test/TestUtil.java
@@ -28,7 +28,9 @@ import org.jetbrains.annotations.Nullable;
 
 import net.fabricmc.mappingio.MappingWriter;
 import net.fabricmc.mappingio.format.MappingFormat;
+import net.fabricmc.mappingio.tree.MappingTree;
 import net.fabricmc.mappingio.tree.MappingTreeView;
+import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
 public final class TestUtil {
 	public static void setResourceRoot(Path path) {
@@ -51,6 +53,19 @@ public final class TestUtil {
 		} catch (URISyntaxException e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	public static MemoryMappingTree createTree() {
+		return createTree(null);
+	}
+
+	public static MemoryMappingTree createTree(MappingTree src) {
+		MemoryMappingTree tree = src == null
+				? new MemoryMappingTree()
+				: new MemoryMappingTree(src);
+		tree.setInDebugMode(true);
+		tree.setIndexByDstNames(true);
+		return tree;
 	}
 
 	@Nullable

--- a/src/test/java/net/fabricmc/mappingio/test/tests/OuterClassNamePropagationTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/OuterClassNamePropagationTest.java
@@ -40,7 +40,6 @@ import net.fabricmc.mappingio.test.TestMappings.MappingDir;
 import net.fabricmc.mappingio.test.visitors.NopMappingVisitor;
 import net.fabricmc.mappingio.test.visitors.SubsetAssertingVisitor;
 import net.fabricmc.mappingio.tree.MappingTreeView;
-import net.fabricmc.mappingio.tree.MemoryMappingTree;
 import net.fabricmc.mappingio.tree.VisitableMappingTree;
 
 public class OuterClassNamePropagationTest {

--- a/src/test/java/net/fabricmc/mappingio/test/tests/OuterClassNamePropagationTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/OuterClassNamePropagationTest.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.mappingio.test.tests;
 
+import static net.fabricmc.mappingio.test.TestUtil.createTree;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -49,7 +50,7 @@ public class OuterClassNamePropagationTest {
 
 	@BeforeAll
 	public static void setup() throws IOException {
-		MappingTreeView tree = acceptMappings(new MemoryMappingTree());
+		MappingTreeView tree = acceptMappings(createTree());
 		srcNamespace = tree.getSrcNamespace();
 		dstNamespaces = tree.getDstNamespaces();
 
@@ -90,7 +91,7 @@ public class OuterClassNamePropagationTest {
 		for (int pass = 1; pass <= 2; pass++) {
 			boolean processRemappedDstNames = pass == 1;
 
-			VisitableMappingTree tree = new MemoryMappingTree();
+			VisitableMappingTree tree = createTree();
 			acceptMappings(new OuterClassNamePropagator(tree, dstNamespaces, processRemappedDstNames));
 			tree.accept(new OuterClassNameChecker(true, dstNamespaces, processRemappedDstNames));
 
@@ -103,14 +104,14 @@ public class OuterClassNamePropagationTest {
 		for (int pass = 1; pass <= 2; pass++) {
 			boolean processRemappedDstNames = pass == 1;
 
-			VisitableMappingTree tree = acceptMappings(new MemoryMappingTree());
+			VisitableMappingTree tree = acceptMappings(createTree());
 			tree.propagateOuterClassNames(processRemappedDstNames);
 			tree.accept(new OuterClassNameChecker(true, dstNamespaces, processRemappedDstNames));
 
 			checkDiskEquivalence(tree, processRemappedDstNames);
 		}
 
-		VisitableMappingTree tree = acceptMappings(new MemoryMappingTree());
+		VisitableMappingTree tree = acceptMappings(createTree());
 
 		assertThrows(UnsupportedOperationException.class, () -> tree.propagateOuterClassNames(
 				dstNamespaces.get(0),
@@ -132,7 +133,7 @@ public class OuterClassNamePropagationTest {
 					? TestMappings.PROPAGATION.PROPAGATED
 					: TestMappings.PROPAGATION.PROPAGATED_EXCEPT_REMAPPED_DST;
 
-			VisitableMappingTree diskTree = dir.read(format, new MemoryMappingTree());
+			VisitableMappingTree diskTree = dir.read(format, createTree());
 
 			tree.accept(new FlatAsRegularMappingVisitor(new SubsetAssertingVisitor(diskTree, format, null)));
 			diskTree.accept(new FlatAsRegularMappingVisitor(new SubsetAssertingVisitor(tree, null, format)));

--- a/src/test/java/net/fabricmc/mappingio/test/tests/reading/EmptyContentReadTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/reading/EmptyContentReadTest.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.mappingio.test.tests.reading;
 
+import static net.fabricmc.mappingio.test.TestUtil.createTree;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
@@ -36,14 +37,13 @@ import net.fabricmc.mappingio.format.srg.TsrgFileReader;
 import net.fabricmc.mappingio.format.tiny.Tiny1FileReader;
 import net.fabricmc.mappingio.format.tiny.Tiny2FileReader;
 import net.fabricmc.mappingio.test.visitors.VisitOrderVerifyingVisitor;
-import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
 public class EmptyContentReadTest {
 	private MappingVisitor target;
 
 	@BeforeEach
 	public void instantiateTree() {
-		target = new VisitOrderVerifyingVisitor(new MemoryMappingTree());
+		target = new VisitOrderVerifyingVisitor(createTree());
 	}
 
 	@Test

--- a/src/test/java/net/fabricmc/mappingio/test/tests/reading/ValidContentReadTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/reading/ValidContentReadTest.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.mappingio.test.tests.reading;
 
+import static net.fabricmc.mappingio.test.TestUtil.createTree;
+
 import java.nio.file.Files;
 
 import org.jetbrains.annotations.Nullable;
@@ -59,8 +61,8 @@ public class ValidContentReadTest {
 		// TODO: The Tiny v2 spec also disallows repeated elements, there should at least be warnings
 		boolean allowConsecutiveDuplicateElementVisits = dir == TestMappings.READING.REPEATED_ELEMENTS;
 
-		VisitableMappingTree referenceTree = dir.generate(new MemoryMappingTree());
-		VisitableMappingTree tree = new MemoryMappingTree();
+		VisitableMappingTree referenceTree = dir.generate(createTree());
+		VisitableMappingTree tree = createTree();
 
 		dir.read(format, new VisitOrderVerifyingVisitor(tree, allowConsecutiveDuplicateElementVisits));
 		assertEqual(tree, format, referenceTree, allowConsecutiveDuplicateElementVisits);
@@ -69,7 +71,7 @@ public class ValidContentReadTest {
 			return;
 		}
 
-		tree = new MemoryMappingTree();
+		tree = createTree();
 		String newSrcNs = format.features().hasNamespaces()
 				? referenceTree.getDstNamespaces().get(0)
 				: MappingUtil.NS_TARGET_FALLBACK;

--- a/src/test/java/net/fabricmc/mappingio/test/tests/reading/ValidContentReadTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/reading/ValidContentReadTest.java
@@ -33,7 +33,6 @@ import net.fabricmc.mappingio.test.TestMappings.MappingDir;
 import net.fabricmc.mappingio.test.visitors.SubsetAssertingVisitor;
 import net.fabricmc.mappingio.test.visitors.VisitOrderVerifyingVisitor;
 import net.fabricmc.mappingio.tree.MappingTreeView;
-import net.fabricmc.mappingio.tree.MemoryMappingTree;
 import net.fabricmc.mappingio.tree.VisitableMappingTree;
 
 public class ValidContentReadTest {

--- a/src/test/java/net/fabricmc/mappingio/test/tests/tree/DebugModeTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/tree/DebugModeTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2024 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.mappingio.test.tests.tree;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static net.fabricmc.mappingio.test.TestUtil.createTree;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import net.fabricmc.mappingio.MappedElementKind;
+import net.fabricmc.mappingio.MappingVisitor;
+import net.fabricmc.mappingio.test.visitors.VisitOrderVerifyingVisitor;
+import net.fabricmc.mappingio.tree.MappingTree.ClassMapping;
+import net.fabricmc.mappingio.tree.MappingTree.FieldMapping;
+import net.fabricmc.mappingio.tree.MappingTree.MethodMapping;
+import net.fabricmc.mappingio.tree.MemoryMappingTree;
+
+public class DebugModeTest {
+	private static final String nsA = "nsA";
+	private static final String nsB = "nsB";
+	private static final String nsC = "nsC";
+	private static final String cls1NsAName = "cls1NsAName";
+	private static final String cls1NsBName = "cls1NsBName";
+	private static final String cls1NsCName = "cls1NsCName";
+	private static final String cls2NsAName = "cls2NsAName";
+	private static final String fld1NsAName = "fld1NsAName";
+	private static final String fld1NsBName = "fld1NsBName";
+	private static final String fldNsADesc = "L" + cls1NsAName + ";";
+	private static final String fld2NsAName = "fld2NsAName";
+	private static final String mth1NsAName = "mth1NsAName";
+	private static final String mth1NsBName = "mth1NsBName";
+	private static final String mth2NsAName = "mth2NsAName";
+	private static final String mthNsADesc = "(L" + cls1NsAName + ";)V";
+	private static final int classPhase = 0;
+	private static final int fieldPhase = 1;
+	private static final int methodPhase = 2;
+	private MemoryMappingTree tree;
+	private MappingVisitor delegate;
+
+	@BeforeEach
+	public void setup() {
+		tree = createTree();
+		delegate = new VisitOrderVerifyingVisitor(tree);
+	}
+
+	/**
+	 * Tests {@link MemoryMappingTree#initClassesByDstNames()}.
+	 */
+	@Test
+	public void duplicateClsDstNameWithinNsAlreadyPresent() throws Exception {
+		for (int i = 0; i <= 2; i++) {
+			tree.setInDebugMode(false);
+			tree.setIndexByDstNames(false);
+
+			delegate.visitHeader();
+			delegate.visitNamespaces(nsA, Arrays.asList(nsB, nsC));
+			delegate.visitContent();
+			delegate.visitClass(cls1NsAName);
+			if (i != 1) delegate.visitDstName(MappedElementKind.CLASS, 0, cls1NsBName);
+			if (i != 0)	delegate.visitDstName(MappedElementKind.CLASS, 1, cls1NsCName);
+			delegate.visitElementContent(MappedElementKind.CLASS);
+			delegate.visitClass(cls2NsAName);
+			if (i != 1) delegate.visitDstName(MappedElementKind.CLASS, 0, cls1NsBName);
+			if (i != 0) delegate.visitDstName(MappedElementKind.CLASS, 1, cls1NsCName);
+			delegate.visitElementContent(MappedElementKind.CLASS);
+			delegate.visitEnd();
+
+			tree.setInDebugMode(true);
+			assertThrows(IllegalStateException.class, () -> tree.setIndexByDstNames(true));
+			setup();
+		}
+	}
+
+	/**
+	 * Tests {@link MemoryMappingTree#visitDstName(MappedElementKind, int, String)}.
+	 */
+	@Test
+	public void insertDuplicateDstNameIntoNsViaVisitation() throws Exception {
+		int ns = 0;
+
+		for (int phase = classPhase; phase <= methodPhase; phase++) {
+			delegate.visitHeader();
+			delegate.visitNamespaces(nsA, Arrays.asList(nsB, nsC));
+			delegate.visitContent();
+			delegate.visitClass(cls1NsAName);
+			delegate.visitDstName(MappedElementKind.CLASS, ns, cls1NsBName);
+			delegate.visitElementContent(MappedElementKind.CLASS);
+			ClassMapping cls1 = tree.getClass(cls1NsAName);
+
+			if (phase == classPhase) {
+				delegate.visitClass(cls2NsAName);
+				assertThrows(IllegalArgumentException.class, () -> delegate.visitDstName(MappedElementKind.CLASS, ns, cls1NsBName));
+				assertEquals(cls1, tree.getClass(cls1NsBName, ns));
+			} else if (phase == fieldPhase) {
+				delegate.visitField(fld1NsAName, fldNsADesc);
+				delegate.visitDstName(MappedElementKind.FIELD, ns, fld1NsBName);
+				delegate.visitElementContent(MappedElementKind.FIELD);
+				delegate.visitField(fld2NsAName, fldNsADesc);
+				assertThrows(IllegalArgumentException.class, () -> delegate.visitDstName(MappedElementKind.FIELD, ns, fld1NsBName));
+				assertEquals(cls1.getField(fld1NsAName, fldNsADesc), cls1.getField(fld1NsBName, tree.mapDesc(fldNsADesc, ns), ns));
+			} else {
+				delegate.visitMethod(mth1NsAName, mthNsADesc);
+				delegate.visitDstName(MappedElementKind.METHOD, ns, mth1NsBName);
+				delegate.visitElementContent(MappedElementKind.METHOD);
+				MethodMapping mth1 = cls1.getMethod(mth1NsAName, mthNsADesc);
+
+				if (phase == methodPhase) {
+					delegate.visitMethod(mth2NsAName, mthNsADesc);
+
+					assertThrows(IllegalArgumentException.class, () -> delegate.visitDstName(MappedElementKind.METHOD, ns, mth1NsBName));
+					assertEquals(mth1, cls1.getMethod(mth1NsBName, tree.mapDesc(mthNsADesc, ns), ns));
+				}
+
+				// TODO: args and vars
+			}
+
+			delegate.reset();
+		}
+	}
+
+	/**
+	 * Tests {@link MemoryMappingTree#addClass(ClassMapping)},
+	 * {@link ClassMapping#addField(FieldMapping)} and
+	 * {@link ClassMapping#addMethod(MethodMapping)}.
+	 */
+	@Test
+	public void insertDuplicateClsDstNameIntoNsViaTreeApi() throws Exception {
+		MemoryMappingTree treeToCopyFrom = createTree();
+		treeToCopyFrom.visitHeader();
+		treeToCopyFrom.visitNamespaces(nsA, Arrays.asList(nsB, nsC));
+		treeToCopyFrom.visitContent();
+		treeToCopyFrom.visitClass(cls2NsAName);
+		treeToCopyFrom.visitDstName(MappedElementKind.CLASS, 0, cls1NsBName);
+		treeToCopyFrom.visitDstName(MappedElementKind.CLASS, 1, cls1NsCName);
+		treeToCopyFrom.visitElementContent(MappedElementKind.CLASS);
+		treeToCopyFrom.visitField(fld2NsAName, fldNsADesc);
+		treeToCopyFrom.visitDstName(MappedElementKind.FIELD, 0, fld1NsBName);
+		treeToCopyFrom.visitElementContent(MappedElementKind.FIELD);
+		treeToCopyFrom.visitMethod(mth2NsAName, mthNsADesc);
+		treeToCopyFrom.visitDstName(MappedElementKind.METHOD, 0, mth1NsBName);
+		treeToCopyFrom.visitElementContent(MappedElementKind.METHOD);
+		treeToCopyFrom.visitEnd();
+
+		ClassMapping cls2ToAdd = treeToCopyFrom.getClass(cls2NsAName);
+		FieldMapping fld2ToAdd = cls2ToAdd.getField(fld2NsAName, fldNsADesc);
+		MethodMapping mth2ToAdd = cls2ToAdd.getMethod(mth2NsAName, mthNsADesc);
+
+		for (int phase = classPhase; phase <= methodPhase; phase++) {
+			delegate.visitHeader();
+			delegate.visitNamespaces(nsA, Arrays.asList(nsB, nsC));
+			delegate.visitContent();
+			delegate.visitClass(cls1NsAName);
+			delegate.visitDstName(MappedElementKind.CLASS, 0, cls1NsBName);
+			delegate.visitDstName(MappedElementKind.CLASS, 1, cls1NsCName);
+			delegate.visitElementContent(MappedElementKind.CLASS);
+
+			if (phase == fieldPhase) {
+				delegate.visitField(fld1NsAName, fldNsADesc);
+				delegate.visitDstName(MappedElementKind.FIELD, 0, fld1NsBName);
+				delegate.visitElementContent(MappedElementKind.FIELD);
+			} else {
+				delegate.visitMethod(mth1NsAName, mthNsADesc);
+				delegate.visitDstName(MappedElementKind.METHOD, 0, mth1NsBName);
+				delegate.visitElementContent(MappedElementKind.METHOD);
+			}
+
+			delegate.visitEnd();
+			ClassMapping cls1 = tree.getClass(cls1NsAName);
+
+			if (phase == classPhase) {
+				assertThrows(IllegalArgumentException.class, () -> tree.addClass(cls2ToAdd));
+			} else if (phase == fieldPhase) {
+				assertThrows(IllegalArgumentException.class, () -> cls1.addField(fld2ToAdd));
+			} else {
+				if (phase == methodPhase) {
+					assertThrows(IllegalArgumentException.class, () -> cls1.addMethod(mth2ToAdd));
+				}
+
+				// TODO: args and vars
+			}
+		}
+	}
+}

--- a/src/test/java/net/fabricmc/mappingio/test/tests/tree/DebugModeTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/tree/DebugModeTest.java
@@ -16,9 +16,9 @@
 
 package net.fabricmc.mappingio.test.tests.tree;
 
+import static net.fabricmc.mappingio.test.TestUtil.createTree;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static net.fabricmc.mappingio.test.TestUtil.createTree;
 
 import java.util.Arrays;
 
@@ -75,7 +75,7 @@ public class DebugModeTest {
 			delegate.visitContent();
 			delegate.visitClass(cls1NsAName);
 			if (i != 1) delegate.visitDstName(MappedElementKind.CLASS, 0, cls1NsBName);
-			if (i != 0)	delegate.visitDstName(MappedElementKind.CLASS, 1, cls1NsCName);
+			if (i != 0) delegate.visitDstName(MappedElementKind.CLASS, 1, cls1NsCName);
 			delegate.visitElementContent(MappedElementKind.CLASS);
 			delegate.visitClass(cls2NsAName);
 			if (i != 1) delegate.visitDstName(MappedElementKind.CLASS, 0, cls1NsBName);

--- a/src/test/java/net/fabricmc/mappingio/test/tests/tree/MergeTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/tree/MergeTest.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.mappingio.test.tests.tree;
 
+import static net.fabricmc.mappingio.test.TestUtil.createTree;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -60,7 +61,7 @@ public class MergeTest {
 
 	@BeforeEach
 	public void setup() {
-		tree = new MemoryMappingTree();
+		tree = createTree();
 		delegate = new VisitOrderVerifyingVisitor(tree);
 	}
 
@@ -288,14 +289,14 @@ public class MergeTest {
 		MappingReader.read(dir.resolve("tree1.tiny"), delegate);
 		MappingReader.read(dir.resolve("tree2.tiny"), delegate);
 
-		MemoryMappingTree referenceTree = new MemoryMappingTree();
+		MemoryMappingTree referenceTree = createTree();
 		MappingReader.read(dir.resolve("tree1+2.tiny"), referenceTree);
 		tree.accept(new FlatAsRegularMappingVisitor(new SubsetAssertingVisitor(referenceTree, null, null)));
 		referenceTree.accept(new FlatAsRegularMappingVisitor(new SubsetAssertingVisitor(tree, null, null)));
 
 		MappingReader.read(dir.resolve("tree3.tiny"), delegate);
 
-		referenceTree = new MemoryMappingTree();
+		referenceTree = createTree();
 		MappingReader.read(dir.resolve("tree1+2+3.tiny"), referenceTree);
 		tree.accept(new FlatAsRegularMappingVisitor(new SubsetAssertingVisitor(referenceTree, null, null)));
 		referenceTree.accept(new FlatAsRegularMappingVisitor(new SubsetAssertingVisitor(tree, null, null)));

--- a/src/test/java/net/fabricmc/mappingio/test/tests/tree/MergeTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/tree/MergeTest.java
@@ -40,6 +40,7 @@ import net.fabricmc.mappingio.test.visitors.VisitOrderVerifyingVisitor;
 import net.fabricmc.mappingio.tree.MappingTree.ClassMapping;
 import net.fabricmc.mappingio.tree.MappingTree.FieldMapping;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
+import net.fabricmc.mappingio.tree.MemoryMappingTree.SrcNameDevoidEntryMergingStrategy;
 
 public class MergeTest {
 	private static final Path dir = TestMappings.MERGING;
@@ -286,6 +287,8 @@ public class MergeTest {
 
 	@Test
 	public void diskMappings() throws IOException {
+		tree.setSrcNameDevoidEntryMergingStrategy(SrcNameDevoidEntryMergingStrategy.REJECT_AMBIGUOUS);
+		// Same namespaces, same order
 		MappingReader.read(dir.resolve("tree1.tiny"), delegate);
 		MappingReader.read(dir.resolve("tree2.tiny"), delegate);
 
@@ -294,10 +297,19 @@ public class MergeTest {
 		tree.accept(new FlatAsRegularMappingVisitor(new SubsetAssertingVisitor(referenceTree, null, null)));
 		referenceTree.accept(new FlatAsRegularMappingVisitor(new SubsetAssertingVisitor(tree, null, null)));
 
+		// Same namespaces, different order
 		MappingReader.read(dir.resolve("tree3.tiny"), delegate);
 
 		referenceTree = createTree();
 		MappingReader.read(dir.resolve("tree1+2+3.tiny"), referenceTree);
+		tree.accept(new FlatAsRegularMappingVisitor(new SubsetAssertingVisitor(referenceTree, null, null)));
+		referenceTree.accept(new FlatAsRegularMappingVisitor(new SubsetAssertingVisitor(tree, null, null)));
+
+		// New namespace as source, some existing ones as destination
+		MappingReader.read(dir.resolve("tree4.tiny"), delegate);
+
+		referenceTree = createTree();
+		MappingReader.read(dir.resolve("tree1+2+3+4.tiny"), referenceTree);
 		tree.accept(new FlatAsRegularMappingVisitor(new SubsetAssertingVisitor(referenceTree, null, null)));
 		referenceTree.accept(new FlatAsRegularMappingVisitor(new SubsetAssertingVisitor(tree, null, null)));
 	}

--- a/src/test/java/net/fabricmc/mappingio/test/tests/tree/MetadataTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/tree/MetadataTest.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.mappingio.test.tests.tree;
 
+import static net.fabricmc.mappingio.test.TestUtil.createTree;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -33,7 +34,6 @@ import org.junit.jupiter.api.Test;
 import net.fabricmc.mappingio.MappingFlag;
 import net.fabricmc.mappingio.test.TestMappings;
 import net.fabricmc.mappingio.test.visitors.NopMappingVisitor;
-import net.fabricmc.mappingio.tree.MemoryMappingTree;
 import net.fabricmc.mappingio.tree.VisitableMappingTree;
 
 public class MetadataTest {
@@ -44,7 +44,7 @@ public class MetadataTest {
 
 	@BeforeAll
 	public static void setup() throws Exception {
-		tree = TestMappings.generateValid(new MemoryMappingTree());
+		tree = TestMappings.generateValid(createTree());
 		tree.getMetadata().clear();
 
 		for (int i = 0; i < 40; i++) {

--- a/src/test/java/net/fabricmc/mappingio/test/tests/tree/SetNamespacesTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/tree/SetNamespacesTest.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.mappingio.test.tests.tree;
 
+import static net.fabricmc.mappingio.test.TestUtil.createTree;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -36,7 +37,7 @@ public class SetNamespacesTest {
 
 	@BeforeEach
 	public void setup() throws IOException {
-		tree = TestMappings.generateValid(new MemoryMappingTree());
+		tree = TestMappings.generateValid(createTree());
 
 		srcNs = tree.getSrcNamespace();
 		dstNs0 = tree.getDstNamespaces().get(0);

--- a/src/test/java/net/fabricmc/mappingio/test/tests/visiting/VisitEndTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/visiting/VisitEndTest.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.mappingio.test.tests.visiting;
 
+import static net.fabricmc.mappingio.test.TestUtil.createTree;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -57,7 +58,7 @@ public class VisitEndTest {
 		}
 
 		MappingTreeView supTree = dir.supportsGeneration()
-				? dir.generate(new MemoryMappingTree())
+				? dir.generate(createTree())
 				: null;
 
 		checkCompliance(dir, format, 1, true, supTree);
@@ -92,7 +93,7 @@ public class VisitEndTest {
 			this.supTree = supTree;
 			this.subFormat = subFormat;
 			this.dir = dir;
-			this.tree = new MemoryMappingTree();
+			this.tree = createTree();
 			this.oldTrees = new MappingTree[visitPassCountToFinish - 1];
 		}
 
@@ -200,8 +201,8 @@ public class VisitEndTest {
 				return true;
 			}
 
-			oldTrees[finishedVisitPassCount - 1] = new MemoryMappingTree(tree);
-			tree = new MemoryMappingTree();
+			oldTrees[finishedVisitPassCount - 1] = createTree(tree);
+			tree = createTree();
 			return false;
 		}
 

--- a/src/test/java/net/fabricmc/mappingio/test/tests/writing/WriteTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/writing/WriteTest.java
@@ -39,7 +39,6 @@ import net.fabricmc.mappingio.test.TestMappings.MappingDir;
 import net.fabricmc.mappingio.test.TestUtil;
 import net.fabricmc.mappingio.test.visitors.SubsetAssertingVisitor;
 import net.fabricmc.mappingio.tree.MappingTreeView;
-import net.fabricmc.mappingio.tree.MemoryMappingTree;
 import net.fabricmc.mappingio.tree.VisitableMappingTree;
 
 public class WriteTest {

--- a/src/test/java/net/fabricmc/mappingio/test/tests/writing/WriteTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/writing/WriteTest.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.mappingio.test.tests.writing;
 
+import static net.fabricmc.mappingio.test.TestUtil.createTree;
+
 import java.io.IOException;
 import java.nio.file.Path;
 
@@ -59,7 +61,7 @@ public class WriteTest {
 		}
 
 		Path path = targetDir.resolve(TestUtil.getFileName(format));
-		MappingTreeView tree = dir.generate(new MemoryMappingTree());
+		MappingTreeView tree = dir.generate(createTree());
 		MappingVisitor target = MappingWriter.create(path, format);
 
 		if (dir.isIn(TestMappings.PROPAGATION.BASE_DIR) && !format.features().hasNamespaces()) {
@@ -83,7 +85,7 @@ public class WriteTest {
 	}
 
 	private void readWithMio(MappingTreeView origTree, Path outputPath, MappingFormat outputFormat) throws Exception {
-		VisitableMappingTree writtenTree = new MemoryMappingTree();
+		VisitableMappingTree writtenTree = createTree();
 		MappingReader.read(outputPath, outputFormat, writtenTree);
 
 		writtenTree.accept(new FlatAsRegularMappingVisitor(new SubsetAssertingVisitor(origTree, null, outputFormat)));
@@ -104,7 +106,7 @@ public class WriteTest {
 		if (format == MappingFormat.PROGUARD_FILE) return;
 
 		// SrgUtils can't handle empty dst names
-		VisitableMappingTree dstNsCompTree = new MemoryMappingTree();
+		VisitableMappingTree dstNsCompTree = createTree();
 		tree.accept(
 				// TODO: Remove once https://github.com/neoforged/SRGUtils/issues/9 is fixed
 				new MappingNsCompleter(

--- a/src/test/resources/merging/tree1+2+3+4.tiny
+++ b/src/test/resources/merging/tree1+2+3+4.tiny
@@ -1,0 +1,9 @@
+tiny	2	0	nsA	nsB	nsC	nsD
+c	cls1NsAName	cls1NsBName	cls1NsCName2	cls1NsDName
+	f	I	fld1NsAName		fld1NsCName	
+		c	fld1 comment
+	f	I	fld2NsAName	fld2NsBName	fld2NsCName	fld2NsDName
+	f	I	fld3NsAName	fld3NsBName	fld3NsCName	fld3NsDName
+	m	()I	mth1NsAName	mth1NsBName2	mth1NsCName	mth1NsDName
+		p	1	arg1NsAName	arg1NsBName	arg1NsCName	
+		v	2	2	2	var1NsAName	var1NsBName	var1NsCName	

--- a/src/test/resources/merging/tree1+2+3.tiny
+++ b/src/test/resources/merging/tree1+2+3.tiny
@@ -1,9 +1,9 @@
-tiny	2	0	source	target	target2
-c	class_1	class1Ns0Rename	class1Ns1Rename2
-	f	I	field_1		field1Ns1Rename
-		c	field_1 comment
-	f	I	field_2	field2Ns0Rename	field2Ns1Rename
-	f	I	field_3	field3Ns0Rename	field3Ns1Rename
-	m	()I	method_1	method1Ns0Rename	method1Ns1Rename
-		p	1	param_1	param1Ns0Rename	param1Ns1Rename
-		v	2	2	2	var_1	var1Ns0Rename	var1Ns1Rename
+tiny	2	0	nsA	nsB	nsC
+c	cls1NsAName	cls1NsBName	cls1NsCName2
+	f	I	fld1NsAName		fld1NsCName
+		c	fld1 comment
+	f	I	fld2NsAName	fld2NsBName	fld2NsCName
+	f	I	fld3NsAName	fld3NsBName	fld3NsCName
+	m	()I	mth1NsAName	mth1NsBName	mth1NsCName
+		p	1	arg1NsAName	arg1NsBName	arg1NsCName
+		v	2	2	2	var1NsAName	var1NsBName	var1NsCName

--- a/src/test/resources/merging/tree1+2+3.tiny
+++ b/src/test/resources/merging/tree1+2+3.tiny
@@ -2,7 +2,7 @@ tiny	2	0	source	target	target2
 c	class_1	class1Ns0Rename	class1Ns1Rename2
 	f	I	field_1		field1Ns1Rename
 		c	field_1 comment
-	f	I	field_2	field2Ns0Rename	
+	f	I	field_2	field2Ns0Rename	field2Ns1Rename
 	f	I	field_3	field3Ns0Rename	field3Ns1Rename
 	m	()I	method_1	method1Ns0Rename	method1Ns1Rename
 		p	1	param_1	param1Ns0Rename	param1Ns1Rename

--- a/src/test/resources/merging/tree1+2.tiny
+++ b/src/test/resources/merging/tree1+2.tiny
@@ -1,7 +1,7 @@
-tiny	2	0	source	target	target2
-c	class_1	class1Ns0Rename	class1Ns1Rename
-	f	I	field_1		field1Ns1Rename
-	f	I	field_2	field2Ns0Rename	
-	m	()I	method_1	method1Ns0Rename	method1Ns1Rename
-		p	1	param_1	param1Ns0Rename	param1Ns1Rename
-		v	2	2	2	var_1	var1Ns0Rename	var1Ns1Rename
+tiny	2	0	nsA	nsB	nsC
+c	cls1NsAName	cls1NsBName	cls1NsCName
+	f	I	fld1NsAName		fld1NsCName
+	f	I	fld2NsAName	fld2NsBName	
+	m	()I	mth1NsAName	mth1NsBName	mth1NsCName
+		p	1	arg1NsAName	arg1NsBName	arg1NsCName
+		v	2	2	2	var1NsAName	var1NsBName	var1NsCName

--- a/src/test/resources/merging/tree1.tiny
+++ b/src/test/resources/merging/tree1.tiny
@@ -1,6 +1,6 @@
-tiny	2	0	source	target	target2
-c	class_1	class1Ns0Rename	
-	f	I	field_1		field1Ns1Rename
-	m	()I	method_1		method1Ns1Rename
-		p	1	param_1		param1Ns1Rename
-		v	2	2	-1	var_1	var1Ns0Rename	
+tiny	2	0	nsA	nsB	nsC
+c	cls1NsAName	cls1NsBName	
+	f	I	fld1NsAName		fld1NsCName
+	m	()I	mth1NsAName		mth1NsCName
+		p	1	arg1NsAName		arg1NsCName
+		v	2	2	-1	var1NsAName	var1NsBName	

--- a/src/test/resources/merging/tree2.tiny
+++ b/src/test/resources/merging/tree2.tiny
@@ -1,7 +1,7 @@
-tiny	2	0	source	target	target2
-c	class_1	class1Ns0Rename	class1Ns1Rename
-	f	I	field_1		field1Ns1Rename
-	f	I	field_2	field2Ns0Rename	
-	m	()I	method_1	method1Ns0Rename	
-		p	1	param_1	param1Ns0Rename	
-		v	2	2	2	var_1		var1Ns1Rename
+tiny	2	0	nsA	nsB	nsC
+c	cls1NsAName	cls1NsBName	cls1NsCName
+	f	I	fld1NsAName		fld1NsCName
+	f	I	fld2NsAName	fld2NsBName	
+	m	()I	mth1NsAName	mth1NsBName	
+		p	1	arg1NsAName	arg1NsBName	
+		v	2	2	2	var1NsAName		var1NsCName

--- a/src/test/resources/merging/tree3.tiny
+++ b/src/test/resources/merging/tree3.tiny
@@ -1,6 +1,6 @@
-tiny	2	0	target2	target	source
-c	class1Ns1Rename2		class_1
-	f	I	field1Ns1Rename		field_1
-		c	field_1 comment
-	f	I	field2Ns1Rename	field2Ns0Rename	
-	f	I	field3Ns1Rename	field3Ns0Rename	field_3
+tiny	2	0	nsC	nsB	nsA
+c	cls1NsCName2		cls1NsAName
+	f	I	fld1NsCName		fld1NsAName
+		c	fld1 comment
+	f	I	fld2NsCName	fld2NsBName	
+	f	I	fld3NsCName	fld3NsBName	fld3NsAName

--- a/src/test/resources/merging/tree4.tiny
+++ b/src/test/resources/merging/tree4.tiny
@@ -1,0 +1,6 @@
+tiny	2	0	nsD	nsC	nsB
+c	cls1NsDName		cls1NsBName
+	f	I	fld1NsDName		fld1NsBName
+	f	I	fld2NsDName		fld2NsBName
+	f	I	fld3NsDName	fld3NsCName	
+	m	()I	mth1NsDName	mth1NsCName	mth1NsBName2


### PR DESCRIPTION
Currently, if a tree has
   nsA   |   nsB
---------|--------- 
 cls1NsAName | cls1NsBName

and you want to merge
   nsB   |   nsC   
---------|--------- 
 cls1NsBName | cls1NsCName 

`cls1NsCName` never finds its way into the tree, as the visit pass doesn't supply a `nsA` name. Even worse, if you visit with `nsC` on the source and `nsB` on the destination side, an exception is thrown, since the incoming source namespace (`nsC`) doesn't exist in the tree yet.

Both of these cases can be solved by iterating all incoming namespaces that actually are present in the tree (`nsB` in this case), searching for entries with the same name (here: `cls1NsBName`) and if found, merging the new data into that existing entry, leading to the following result:
   nsA   |   nsB   |   nsC   
---------|---------|--------- 
 cls1NsAName | cls1NsBName | cls1NsCName 

That's exactly what this PR does, however there's an edge case I wasn't sure how to handle: What if we find a match in more than one namespace, but each one belonging to a different entry? 
Tree:
   nsA   |     nsB     |     nsC     
---------|-------------|------------- 
 cls1NsAName | someNsBName |             
 cls2NsAName |             | someNsCName 

To be merged:
     nsB     |     nsC     |     nsD     
-------------|-------------|------------- 
 someNsBName | someNsCName | someNsDName 

This would match both `cls1` and `cls2`. As of now, this PR returns after merging with the first match, but we could of course merge with the remaining matches too or throw an exception instead. What are your opinions on this?