### PR TITLE
feat: add getter for `next` visitor in `ForwardingMappingVisitor`

### DIFF
--- a/src/main/java/net/fabricmc/mappingio/adapter/ForwardingMappingVisitor.java
+++ b/src/main/java/net/fabricmc/mappingio/adapter/ForwardingMappingVisitor.java
@@ -119,5 +119,12 @@ public abstract class ForwardingMappingVisitor implements MappingVisitor {
 		next.visitComment(targetKind, comment);
 	}
 
+	/**
+	 * @return the {@link MappingVisitor} this visitor forwards
+	 */
+	public MappingVisitor getNext() {
+		return next;
+	}
+
 	protected final MappingVisitor next;
 }


### PR DESCRIPTION
Unblocks https://github.com/FabricMC/fabric-loom/pull/1323