### PR TITLE
Fix `EnigmaWriterBase` not writing missing destination namespace nest members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fixed `EnigmaWriterBase` not writing missing destination namespace nest members when nest depth differs between source and destination names
 
 ## [0.8.0] - 2025-11-02
 - Added `EmptyElementFilter`, an adapter which filters out elements that effectively don't contain any data

--- a/mapping-io-extras/.gitignore
+++ b/mapping-io-extras/.gitignore
@@ -1,1 +1,5 @@
 /build/
+/bin/
+/.settings/
+/.classpath
+/.project

--- a/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaWriterBase.java
+++ b/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaWriterBase.java
@@ -181,6 +181,8 @@ abstract class EnigmaWriterBase implements MappingWriter {
 	protected void writeMismatchedOrMissingClasses() throws IOException {
 		indent = 0;
 		int srcStart = 0;
+		int lastDstEnd = -1;
+		boolean entryWritten = false;
 
 		do {
 			int srcEnd = getNextOuterEnd(srcClassName, srcStart);
@@ -189,6 +191,12 @@ abstract class EnigmaWriterBase implements MappingWriter {
 
 			if (!lastWrittenClass.regionMatches(srcStart, srcClassName, srcStart, srcLen) // writtenPart.startsWith(srcPart)
 					|| srcEnd < lastWrittenClass.length() && lastWrittenClass.charAt(srcEnd) != '$') { // no trailing characters in writtenPart -> startsWith = equals
+				if (entryWritten) {
+					writer.write('\n');
+				} else {
+					entryWritten = true;
+				}
+
 				writeIndent(0);
 				writer.write("CLASS ");
 				writer.write(srcClassName, srcStart, srcLen);
@@ -203,7 +211,7 @@ abstract class EnigmaWriterBase implements MappingWriter {
 					}
 
 					if (dstStart >= 0) {
-						int dstEnd = getNextOuterEnd(dstName, dstStart);
+						int dstEnd = lastDstEnd = getNextOuterEnd(dstName, dstStart);
 						if (dstEnd < 0) dstEnd = dstName.length();
 						int dstLen = dstEnd - dstStart;
 
@@ -214,13 +222,20 @@ abstract class EnigmaWriterBase implements MappingWriter {
 						}
 					}
 				}
-
-				writer.write('\n');
 			}
 
 			indent++;
 			srcStart = srcEnd + 1;
 		} while (srcStart < srcClassName.length());
+
+		if (entryWritten) {
+			if (lastDstEnd >= 0) {
+				// Nest depth mismatch between source and destination names - write missing nest members
+				writer.write(dstName, lastDstEnd, dstName.length() - lastDstEnd);
+			}
+
+			writer.write('\n');
+		}
 
 		lastWrittenClass = srcClassName;
 		dstName = null;

--- a/src/test/java/net/fabricmc/mappingio/test/tests/writing/EnigmaInnerClassesRoundtripTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/writing/EnigmaInnerClassesRoundtripTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.mappingio.test.tests.writing;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import org.junit.jupiter.api.Test;
+
+import net.fabricmc.mappingio.format.enigma.EnigmaFileReader;
+import net.fabricmc.mappingio.format.enigma.EnigmaFileWriter;
+import net.fabricmc.mappingio.tree.MappingTree.ClassMapping;
+import net.fabricmc.mappingio.tree.MemoryMappingTree;
+
+public class EnigmaInnerClassesRoundtripTest {
+	@Test
+	public void missingNestHost() throws Exception {
+		String mappingContents = "CLASS innerclass outerclass$1\n";
+
+		MemoryMappingTree tree = new MemoryMappingTree();
+
+		assertDoesNotThrow(() -> EnigmaFileReader.read(new StringReader(mappingContents), tree), "Couldn't read mapping:\n" + mappingContents);
+
+		ClassMapping mappingBySrc = tree.getClass("innerclass");
+		ClassMapping mappingByDst = tree.getClass("outerclass$1", tree.getMaxNamespaceId() - 1);
+		ClassMapping outerByDst = tree.getClass("outerclass", tree.getMaxNamespaceId() - 1);
+
+		assertNotNull(mappingBySrc, "Cannot find class by source name");
+		assertNotNull(mappingByDst, "Cannot find class by destination name");
+		assertNull(outerByDst);
+		assertEquals(mappingBySrc, mappingByDst);
+		assertEquals("innerclass", mappingBySrc.getSrcName());
+		assertEquals("outerclass$1", mappingBySrc.getDstName(tree.getMaxNamespaceId() - 1));
+
+		StringWriter sw = new StringWriter();
+		try (EnigmaFileWriter writer = new EnigmaFileWriter(sw)) {
+			tree.accept(writer);
+		}
+
+		assertEquals(mappingContents, sw.toString());
+	}
+}

--- a/src/test/java/net/fabricmc/mappingio/test/tests/writing/EnigmaInnerClassesRoundtripTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/writing/EnigmaInnerClassesRoundtripTest.java
@@ -35,7 +35,6 @@ public class EnigmaInnerClassesRoundtripTest {
 	@Test
 	public void missingNestHost() throws Exception {
 		String mappingContents = "CLASS innerclass outerclass$1\n";
-
 		MemoryMappingTree tree = new MemoryMappingTree();
 
 		assertDoesNotThrow(() -> EnigmaFileReader.read(new StringReader(mappingContents), tree), "Couldn't read mapping:\n" + mappingContents);
@@ -52,6 +51,7 @@ public class EnigmaInnerClassesRoundtripTest {
 		assertEquals("outerclass$1", mappingBySrc.getDstName(tree.getMaxNamespaceId() - 1));
 
 		StringWriter sw = new StringWriter();
+
 		try (EnigmaFileWriter writer = new EnigmaFileWriter(sw)) {
 			tree.accept(writer);
 		}


### PR DESCRIPTION
This happens when nest depth differs between source and destination names in enigma files. This can easily be provoked by making a class that was in its own compilation unit an inner class (at least insofar the destination namespace name is concerned) of an unrelated class.

To give an example, the current behaviour is as follows: A `a` -> `b$c` mapping will be written as `CLASS a b`. A `a$b` -> `c$d$e` mapping will be written as `CLASS a$b c$d`.

The new behaviour aligns with the expected behaviour of not voiding information. In the examples above, it will produce `CLASS a b$c` and `CLASS a$b c$d$e` respectively. Thus it will be capable of roundtripping such mapping files.

Keep in mind that a lot of tooling doesn't use class names to evaluate the nest hosts. This PR does not change any behaviour regarding that, or in other words, just because the name indicates that a class is an inner class of another doesn't mean that it actually is considered to be as such according to javac or the JVM.

Further, dependent projects such as Enigma do not tolerate inner classes that have been created this way. However, prior to this commit Enigma's UI bugged out to the point where one cannot interact with these classes. Now the UI is bugged out, but the classes can at least be interacted with. However, this is an issue with either the reading process or some UI aspect within enigma, not within the enigma writing process (as far as I am concerned).