### PR TITLE
Add support for Markdown javadoc

### DIFF
--- a/src/main/java/net/fabricmc/mappingio/CommentStyle.java
+++ b/src/main/java/net/fabricmc/mappingio/CommentStyle.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.mappingio;
+
+/**
+ * A kind of Java documentation comment.
+ */
+public enum CommentStyle {
+	HTML,
+	MARKDOWN
+}

--- a/src/main/java/net/fabricmc/mappingio/FlatMappingVisitor.java
+++ b/src/main/java/net/fabricmc/mappingio/FlatMappingVisitor.java
@@ -63,39 +63,85 @@ public interface FlatMappingVisitor {
 	}
 
 	boolean visitClass(String srcName, @Nullable String[] dstNames) throws IOException;
+	/**
+	 * @deprecated Use {@link #visitClassComment(String, String[], String, CommentStyle)} instead.
+	 */
+	@Deprecated
 	void visitClassComment(String srcName, @Nullable String[] dstNames, String comment) throws IOException;
+	default void visitClassComment(String srcName, @Nullable String[] dstNames, String comment, CommentStyle style) throws IOException {
+		visitClassComment(srcName, dstNames, comment);
+	}
 
 	boolean visitField(String srcClsName, String srcName, @Nullable String srcDesc,
 			@Nullable String[] dstClsNames, @Nullable String[] dstNames, @Nullable String[] dstDescs) throws IOException;
+	/**
+	 * @deprecated Use {@link #visitFieldComment(String, String, String, String[], String[], String[], String, CommentStyle)} instead.
+	 */
+	@Deprecated
 	void visitFieldComment(String srcClsName, String srcName, @Nullable String srcDesc,
 			@Nullable String[] dstClsNames, @Nullable String[] dstNames, @Nullable String[] dstDescs,
 			String comment) throws IOException;
+	default void visitFieldComment(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String[] dstClsNames, @Nullable String[] dstNames, @Nullable String[] dstDescs,
+			String comment, CommentStyle style) throws IOException {
+		visitFieldComment(srcClsName, srcName, srcDesc, dstClsNames, dstNames, dstDescs, comment);
+	}
 
 	boolean visitMethod(String srcClsName, String srcName, @Nullable String srcDesc,
 			@Nullable String[] dstClsNames, @Nullable String[] dstNames, @Nullable String[] dstDescs) throws IOException;
+	/**
+	 * @deprecated Use {@link #visitMethodComment(String, String, String, String[], String[], String[], String, CommentStyle)} instead.
+	 */
+	@Deprecated
 	void visitMethodComment(String srcClsName, String srcName, @Nullable String srcDesc,
 			@Nullable String[] dstClsNames, @Nullable String[] dstNames, @Nullable String[] dstDescs,
 			String comment) throws IOException;
+	default void visitMethodComment(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String[] dstClsNames, @Nullable String[] dstNames, @Nullable String[] dstDescs,
+			String comment, CommentStyle style) throws IOException {
+		visitMethodComment(srcClsName, srcName, srcDesc, dstClsNames, dstNames, dstDescs, comment);
+	}
 
 	boolean visitMethodArg(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
 			int argPosition, int lvIndex, @Nullable String srcName,
 			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames,
 			@Nullable String[] dstMethodDescs, String[] dstNames) throws IOException;
+	/**
+	 * @deprecated Use {@link #visitMethodArgComment(String, String, String, int, int, String, String[], String[], String[], String[], String, CommentStyle)} instead.
+	 */
+	@Deprecated
 	void visitMethodArgComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
 			int argPosition, int lvIndex, @Nullable String srcName,
 			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames,
 			@Nullable String[] dstMethodDescs, @Nullable String[] dstNames,
 			String comment) throws IOException;
+	default void visitMethodArgComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int argPosition, int lvIndex, @Nullable String srcName,
+			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames,
+			@Nullable String[] dstMethodDescs, @Nullable String[] dstNames,
+			String comment, CommentStyle style) throws IOException {
+		visitMethodArgComment(srcClsName, srcMethodName, srcMethodDesc, argPosition, lvIndex, srcName, dstClsNames, dstMethodNames, dstMethodDescs, dstNames, comment);
+	}
 
 	boolean visitMethodVar(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
 			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName,
 			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames,
 			@Nullable String[] dstMethodDescs, String[] dstNames) throws IOException;
+	/**
+	 * @deprecated Use {@link #visitMethodVarComment(String, String, String, int, int, int, int, String, String[], String[], String[], String[], String, CommentStyle)} instead.
+	 */
 	void visitMethodVarComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
 			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName,
 			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames,
 			@Nullable String[] dstMethodDescs, @Nullable String[] dstNames,
 			String comment) throws IOException;
+	default void visitMethodVarComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName,
+			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames,
+			@Nullable String[] dstMethodDescs, @Nullable String[] dstNames,
+			String comment, CommentStyle style) throws IOException {
+		visitMethodVarComment(srcClsName, srcMethodName, srcMethodDesc, lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcName, dstClsNames, dstMethodNames, dstMethodDescs, dstNames, comment);
+	}
 
 	/**
 	 * Finish the visitation pass.
@@ -154,12 +200,28 @@ public interface FlatMappingVisitor {
 		return visitClass(srcName, toArray(dstName));
 	}
 
+	/**
+	 * @deprecated Use {@link #visitClassComment(String, String, CommentStyle)} instead.
+	 */
+	@Deprecated
 	default void visitClassComment(String srcName, String comment) throws IOException {
-		visitClassComment(srcName, (String) null, comment);
+		visitClassComment(srcName, comment, CommentStyle.HTML);
 	}
 
+	/**
+	 * @deprecated Use {@link #visitClassComment(String, String, String, CommentStyle)} instead.
+	 */
+	@Deprecated
 	default void visitClassComment(String srcName, @Nullable String dstName, String comment) throws IOException {
-		visitClassComment(srcName, toArray(dstName), comment);
+		visitClassComment(srcName, dstName, comment, CommentStyle.HTML);
+	}
+
+	default void visitClassComment(String srcName, String comment, CommentStyle style) throws IOException {
+		visitClassComment(srcName, (String) null, comment, style);
+	}
+
+	default void visitClassComment(String srcName, @Nullable String dstName, String comment, CommentStyle style) throws IOException {
+		visitClassComment(srcName, toArray(dstName), comment, style);
 	}
 
 	default boolean visitField(String srcClsName, String srcName, @Nullable String srcDesc,
@@ -174,19 +236,38 @@ public interface FlatMappingVisitor {
 				toArray(dstClsName), toArray(dstName), toArray(dstDesc));
 	}
 
+	/**
+	 * @deprecated Use {@link #visitFieldComment(String, String, String, String, CommentStyle)} instead.
+	 */
+	@Deprecated
 	default void visitFieldComment(String srcClsName, String srcName, @Nullable String srcDesc,
 			String comment) throws IOException {
+		visitFieldComment(srcClsName, srcName, srcDesc, comment, CommentStyle.HTML);
+	}
+
+	/**
+	 * @deprecated Use {@link #visitFieldComment(String, String, String, String, String, String, String, CommentStyle)} instead.
+	 */
+	@Deprecated
+	default void visitFieldComment(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String dstClsName, @Nullable String dstName, @Nullable String dstDesc,
+			String comment) throws IOException {
+		visitFieldComment(srcClsName, srcName, srcDesc, dstClsName, dstName, dstDesc, comment, CommentStyle.HTML);
+	}
+
+	default void visitFieldComment(String srcClsName, String srcName, @Nullable String srcDesc,
+			String comment, CommentStyle style) throws IOException {
 		visitFieldComment(srcClsName, srcName, srcDesc,
 				(String) null, null, null,
-				comment);
+				comment, style);
 	}
 
 	default void visitFieldComment(String srcClsName, String srcName, @Nullable String srcDesc,
 			@Nullable String dstClsName, @Nullable String dstName, @Nullable String dstDesc,
-			String comment) throws IOException {
+			String comment, CommentStyle style) throws IOException {
 		visitFieldComment(srcClsName, srcName, srcDesc,
 				toArray(dstClsName), toArray(dstName), toArray(dstDesc),
-				comment);
+				comment, style);
 	}
 
 	default boolean visitMethod(String srcClsName, String srcName, @Nullable String srcDesc,
@@ -201,19 +282,38 @@ public interface FlatMappingVisitor {
 				toArray(dstClsName), toArray(dstName), toArray(dstDesc));
 	}
 
+	/**
+	 * @deprecated Use {@link #visitMethodComment(String, String, String, String, CommentStyle)} instead.
+	 */
+	@Deprecated
 	default void visitMethodComment(String srcClsName, String srcName, @Nullable String srcDesc,
 			String comment) throws IOException {
+		visitMethodComment(srcClsName, srcName, srcDesc, comment, CommentStyle.HTML);
+	}
+
+	/**
+	 * @deprecated Use {@link #visitMethodComment(String, String, String, String, String, String, String, CommentStyle)} instead.
+	 */
+	@Deprecated
+	default void visitMethodComment(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String dstClsName, @Nullable String dstName, @Nullable String dstDesc,
+			String comment) throws IOException {
+		visitMethodComment(srcClsName, srcName, srcDesc, dstClsName, dstName, dstDesc, comment, CommentStyle.HTML);
+	}
+
+	default void visitMethodComment(String srcClsName, String srcName, @Nullable String srcDesc,
+			String comment, CommentStyle style) throws IOException {
 		visitMethodComment(srcClsName, srcName, srcDesc,
 				(String) null, null, null,
-				comment);
+				comment, style);
 	}
 
 	default void visitMethodComment(String srcClsName, String srcName, @Nullable String srcDesc,
 			@Nullable String dstClsName, @Nullable String dstName, @Nullable String dstDesc,
-			String comment) throws IOException {
+			String comment, CommentStyle style) throws IOException {
 		visitMethodComment(srcClsName, srcName, srcDesc,
 				toArray(dstClsName), toArray(dstName), toArray(dstDesc),
-				comment);
+				comment, style);
 	}
 
 	default boolean visitMethodArg(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
@@ -232,22 +332,43 @@ public interface FlatMappingVisitor {
 				toArray(dstClsName), toArray(dstMethodName), toArray(dstMethodDesc), toArray(dstName));
 	}
 
+	/**
+	 * @deprecated Use {@link #visitMethodArgComment(String, String, String, int, int, String, String, CommentStyle)} instead.
+	 */
+	@Deprecated
 	default void visitMethodArgComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
 			int argPosition, int lvIndex, @Nullable String srcName, String comment) throws IOException {
+		visitMethodArgComment(srcClsName, srcMethodName, srcMethodDesc, argPosition, lvIndex, srcName, comment, CommentStyle.HTML);
+	}
+
+	/**
+	 * @deprecated Use {@link #visitMethodArgComment(String, String, String, int, int, String, String, String, String, String, String, CommentStyle)} instead.
+	 */
+	@Deprecated
+	default void visitMethodArgComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int argPosition, int lvIndex, @Nullable String srcName,
+			@Nullable String dstClsName, @Nullable String dstMethodName,
+			@Nullable String dstMethodDesc, @Nullable String dstName,
+			String comment) throws IOException {
+		visitMethodArgComment(srcClsName, srcMethodName, srcMethodDesc, argPosition, lvIndex, srcName, dstClsName, dstMethodName, dstMethodDesc, dstName, comment, CommentStyle.HTML);
+	}
+
+	default void visitMethodArgComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int argPosition, int lvIndex, @Nullable String srcName, String comment, CommentStyle style) throws IOException {
 		visitMethodArgComment(srcClsName, srcMethodName, srcMethodDesc,
 				argPosition, lvIndex, srcName,
 				(String) null, null, null, null,
-				comment);
+				comment, style);
 	}
 
 	default void visitMethodArgComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
 			int argPosition, int lvIndex, @Nullable String srcName,
 			@Nullable String dstClsName, @Nullable String dstMethodName,
 			@Nullable String dstMethodDesc, @Nullable String dstName,
-			String comment) throws IOException {
+			String comment, CommentStyle style) throws IOException {
 		visitMethodArgComment(srcClsName, srcMethodName, srcMethodDesc, argPosition, lvIndex, srcName,
 				toArray(dstClsName), toArray(dstMethodName), toArray(dstMethodDesc), toArray(dstName),
-				comment);
+				comment, style);
 	}
 
 	default boolean visitMethodVar(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
@@ -267,22 +388,48 @@ public interface FlatMappingVisitor {
 				toArray(dstClsName), toArray(dstMethodName), toArray(dstMethodDesc), toArray(dstName));
 	}
 
+	/**
+	 * @deprecated Use {@link #visitMethodVarComment(String, String, String, int, int, int, int, String, String, CommentStyle)} instead.
+	 */
+	@Deprecated
 	default void visitMethodVarComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
 			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName,
 			String comment) throws IOException {
 		visitMethodVarComment(srcClsName, srcMethodName, srcMethodDesc,
 				lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcName,
-				(String) null, null, null, null,
-				comment);
+				comment, CommentStyle.HTML);
 	}
 
+	/**
+	 * @deprecated Use {@link #visitMethodVarComment(String, String, String, int, int, int, int, String, String, String, String, String, String, CommentStyle)} instead.
+	 */
+	@Deprecated
 	default void visitMethodVarComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
 			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName,
 			@Nullable String dstClsName, @Nullable String dstMethodName, @Nullable String dstMethodDesc,
 			@Nullable String dstName, String comment) throws IOException {
 		visitMethodVarComment(srcClsName, srcMethodName, srcMethodDesc,
 				lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcName,
+				dstClsName, dstMethodName, dstMethodDesc, dstName,
+				comment, CommentStyle.HTML);
+	}
+
+	default void visitMethodVarComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName,
+			String comment, CommentStyle style) throws IOException {
+		visitMethodVarComment(srcClsName, srcMethodName, srcMethodDesc,
+				lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcName,
+				(String) null, null, null, null,
+				comment, style);
+	}
+
+	default void visitMethodVarComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcName,
+			@Nullable String dstClsName, @Nullable String dstMethodName, @Nullable String dstMethodDesc,
+			@Nullable String dstName, String comment, CommentStyle style) throws IOException {
+		visitMethodVarComment(srcClsName, srcMethodName, srcMethodDesc,
+				lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcName,
 				toArray(dstClsName), toArray(dstMethodName), toArray(dstMethodDesc), toArray(dstName),
-				comment);
+				comment, style);
 	}
 }

--- a/src/main/java/net/fabricmc/mappingio/MappingVisitor.java
+++ b/src/main/java/net/fabricmc/mappingio/MappingVisitor.java
@@ -168,6 +168,18 @@ public interface MappingVisitor {
 	 * Comment for the specified element (last content-visited or any parent).
 	 *
 	 * @param comment Comment as a potentially multi-line string.
+	 * @deprecated Use {@link #visitComment(MappedElementKind, String, CommentStyle)} instead.
 	 */
+	@Deprecated
 	void visitComment(MappedElementKind targetKind, String comment) throws IOException;
+
+	/**
+	 * Comment for the specified element (last content-visited or any parent).
+	 *
+	 * @param comment Comment as a potentially multi-line string.
+	 * @param style   The comment style.
+	 */
+	default void visitComment(MappedElementKind targetKind, String comment, CommentStyle style) throws IOException {
+		visitComment(targetKind, comment);
+	}
 }

--- a/src/main/java/net/fabricmc/mappingio/adapter/FlatAsRegularMappingVisitor.java
+++ b/src/main/java/net/fabricmc/mappingio/adapter/FlatAsRegularMappingVisitor.java
@@ -21,6 +21,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
+import net.fabricmc.mappingio.CommentStyle;
+
 import org.jetbrains.annotations.Nullable;
 
 import net.fabricmc.mappingio.FlatMappingVisitor;
@@ -32,7 +34,7 @@ import net.fabricmc.mappingio.MappingVisitor;
  * A mapping visitor that forwards all relevant data to a {@link FlatMappingVisitor}.
  *
  * <p>Element data is relayed upon {@link #visitElementContent(MappedElementKind)}
- * or {@link #visitComment(MappedElementKind, String)} invocation.
+ * or {@link #visitComment(MappedElementKind, String, CommentStyle)} invocation.
  * If no data was collected for the current element, the corresponding {@link FlatMappingVisitor}'s visit method is not called.
  */
 public final class FlatAsRegularMappingVisitor implements MappingVisitor {
@@ -192,25 +194,30 @@ public final class FlatAsRegularMappingVisitor implements MappingVisitor {
 
 	@Override
 	public void visitComment(MappedElementKind targetKind, String comment) throws IOException {
+		visitComment(targetKind, comment, CommentStyle.HTML);
+	}
+
+	@Override
+	public void visitComment(MappedElementKind targetKind, String comment, CommentStyle style) throws IOException {
 		switch (targetKind) {
 		case CLASS:
-			next.visitClassComment(srcClsName, dstClassNames, comment);
+			next.visitClassComment(srcClsName, dstClassNames, comment, style);
 			break;
 		case FIELD:
 			next.visitFieldComment(srcClsName, srcMemberName, srcMemberDesc,
-					dstClassNames, dstMemberNames, dstMemberDescs, comment);
+					dstClassNames, dstMemberNames, dstMemberDescs, comment, style);
 			break;
 		case METHOD:
 			next.visitMethodComment(srcClsName, srcMemberName, srcMemberDesc,
-					dstClassNames, dstMemberNames, dstMemberDescs, comment);
+					dstClassNames, dstMemberNames, dstMemberDescs, comment, style);
 			break;
 		case METHOD_ARG:
 			next.visitMethodArgComment(srcClsName, srcMemberName, srcMemberDesc, argIdx, lvIndex, srcMemberSubName,
-					dstClassNames, dstMemberNames, dstMemberDescs, dstNames, comment);
+					dstClassNames, dstMemberNames, dstMemberDescs, dstNames, comment, style);
 			break;
 		case METHOD_VAR:
 			next.visitMethodVarComment(srcClsName, srcMemberName, srcMemberDesc, argIdx, lvIndex, startOpIdx, endOpIdx, srcMemberSubName,
-					dstClassNames, dstMemberNames, dstMemberDescs, dstNames, comment);
+					dstClassNames, dstMemberNames, dstMemberDescs, dstNames, comment, style);
 			break;
 		}
 	}

--- a/src/main/java/net/fabricmc/mappingio/adapter/FlatAsRegularMappingVisitor.java
+++ b/src/main/java/net/fabricmc/mappingio/adapter/FlatAsRegularMappingVisitor.java
@@ -21,10 +21,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
-import net.fabricmc.mappingio.CommentStyle;
-
 import org.jetbrains.annotations.Nullable;
 
+import net.fabricmc.mappingio.CommentStyle;
 import net.fabricmc.mappingio.FlatMappingVisitor;
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingFlag;

--- a/src/main/java/net/fabricmc/mappingio/adapter/ForwardingMappingVisitor.java
+++ b/src/main/java/net/fabricmc/mappingio/adapter/ForwardingMappingVisitor.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import net.fabricmc.mappingio.CommentStyle;
+
 import org.jetbrains.annotations.Nullable;
 
 import net.fabricmc.mappingio.MappedElementKind;
@@ -117,6 +119,11 @@ public abstract class ForwardingMappingVisitor implements MappingVisitor {
 	@Override
 	public void visitComment(MappedElementKind targetKind, String comment) throws IOException {
 		next.visitComment(targetKind, comment);
+	}
+
+	@Override
+	public void visitComment(MappedElementKind targetKind, String comment, CommentStyle style) throws IOException {
+		next.visitComment(targetKind, comment, style);
 	}
 
 	protected final MappingVisitor next;

--- a/src/main/java/net/fabricmc/mappingio/adapter/ForwardingMappingVisitor.java
+++ b/src/main/java/net/fabricmc/mappingio/adapter/ForwardingMappingVisitor.java
@@ -21,10 +21,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-import net.fabricmc.mappingio.CommentStyle;
-
 import org.jetbrains.annotations.Nullable;
 
+import net.fabricmc.mappingio.CommentStyle;
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingFlag;
 import net.fabricmc.mappingio.MappingVisitor;

--- a/src/main/java/net/fabricmc/mappingio/adapter/RegularAsFlatMappingVisitor.java
+++ b/src/main/java/net/fabricmc/mappingio/adapter/RegularAsFlatMappingVisitor.java
@@ -20,10 +20,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
-import net.fabricmc.mappingio.CommentStyle;
-
 import org.jetbrains.annotations.Nullable;
 
+import net.fabricmc.mappingio.CommentStyle;
 import net.fabricmc.mappingio.FlatMappingVisitor;
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingFlag;

--- a/src/main/java/net/fabricmc/mappingio/adapter/RegularAsFlatMappingVisitor.java
+++ b/src/main/java/net/fabricmc/mappingio/adapter/RegularAsFlatMappingVisitor.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
+import net.fabricmc.mappingio.CommentStyle;
+
 import org.jetbrains.annotations.Nullable;
 
 import net.fabricmc.mappingio.FlatMappingVisitor;
@@ -96,14 +98,19 @@ public final class RegularAsFlatMappingVisitor implements FlatMappingVisitor {
 
 	@Override
 	public void visitClassComment(String srcName, @Nullable String[] dstNames, String comment) throws IOException {
-		if (!visitClass(srcName, dstNames, null)) return;
-		next.visitComment(MappedElementKind.CLASS, comment);
+		visitClassComment(srcName, dstNames, comment, CommentStyle.HTML);
 	}
 
 	@Override
-	public void visitClassComment(String srcName, @Nullable String dstName, String comment) throws IOException {
+	public void visitClassComment(String srcName, @Nullable String[] dstNames, String comment, CommentStyle style) throws IOException {
+		if (!visitClass(srcName, dstNames, null)) return;
+		next.visitComment(MappedElementKind.CLASS, comment, style);
+	}
+
+	@Override
+	public void visitClassComment(String srcName, @Nullable String dstName, String comment, CommentStyle style) throws IOException {
 		if (!visitClass(srcName, null, dstName)) return;
-		next.visitComment(MappedElementKind.CLASS, comment);
+		next.visitComment(MappedElementKind.CLASS, comment, style);
 	}
 
 	@Override
@@ -138,16 +145,23 @@ public final class RegularAsFlatMappingVisitor implements FlatMappingVisitor {
 	public void visitFieldComment(String srcClsName, String srcName, @Nullable String srcDesc,
 			@Nullable String[] dstClsNames, @Nullable String[] dstNames, @Nullable String[] dstDescs,
 			String comment) throws IOException {
+		visitFieldComment(srcClsName, srcName, srcDesc, dstClsNames, dstNames, dstDescs, comment, CommentStyle.HTML);
+	}
+
+	@Override
+	public void visitFieldComment(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String[] dstClsNames, @Nullable String[] dstNames, @Nullable String[] dstDescs,
+			String comment, CommentStyle style) throws IOException {
 		if (!visitField(srcClsName, srcName, srcDesc, dstClsNames, dstNames, dstDescs, null, null, null)) return;
-		next.visitComment(MappedElementKind.FIELD, comment);
+		next.visitComment(MappedElementKind.FIELD, comment, style);
 	}
 
 	@Override
 	public void visitFieldComment(String srcClsName, String srcName, @Nullable String srcDesc,
 			@Nullable String dstClsName, @Nullable String dstName, @Nullable String dstDesc,
-			String comment) throws IOException {
+			String comment, CommentStyle style) throws IOException {
 		if (!visitField(srcClsName, srcName, srcDesc, null, null, null, dstClsName, dstName, dstDesc)) return;
-		next.visitComment(MappedElementKind.FIELD, comment);
+		next.visitComment(MappedElementKind.FIELD, comment, style);
 	}
 
 	@Override
@@ -182,16 +196,23 @@ public final class RegularAsFlatMappingVisitor implements FlatMappingVisitor {
 	public void visitMethodComment(String srcClsName, String srcName, @Nullable String srcDesc,
 			@Nullable String[] dstClsNames, @Nullable String[] dstNames, @Nullable String[] dstDescs,
 			String comment) throws IOException {
+		visitMethodComment(srcClsName, srcName, srcDesc, dstClsNames, dstNames, dstDescs, comment, CommentStyle.HTML);
+	}
+
+	@Override
+	public void visitMethodComment(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String[] dstClsNames, @Nullable String[] dstNames, @Nullable String[] dstDescs,
+			String comment, CommentStyle style) throws IOException {
 		if (!visitMethod(srcClsName, srcName, srcDesc, dstClsNames, dstNames, dstDescs, null, null, null)) return;
-		next.visitComment(MappedElementKind.METHOD, comment);
+		next.visitComment(MappedElementKind.METHOD, comment, style);
 	}
 
 	@Override
 	public void visitMethodComment(String srcClsName, String srcName, @Nullable String srcDesc,
 			@Nullable String dstClsName, @Nullable String dstName, @Nullable String dstDesc,
-			String comment) throws IOException {
+			String comment, CommentStyle style) throws IOException {
 		if (!visitMethod(srcClsName, srcName, srcDesc, null, null, null, dstClsName, dstName, dstDesc)) return;
-		next.visitComment(MappedElementKind.METHOD, comment);
+		next.visitComment(MappedElementKind.METHOD, comment, style);
 	}
 
 	@Override
@@ -235,25 +256,36 @@ public final class RegularAsFlatMappingVisitor implements FlatMappingVisitor {
 			int argPosition, int lvIndex, @Nullable String srcArgName,
 			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames,
 			@Nullable String[] dstMethodDescs, @Nullable String[] dstArgNames, String comment) throws IOException {
+		visitMethodArgComment(srcClsName, srcMethodName, srcMethodDesc,
+				argPosition, lvIndex, srcArgName,
+				dstClsNames, dstMethodNames, dstMethodDescs,
+				dstArgNames, comment, CommentStyle.HTML);
+	}
+
+	@Override
+	public void visitMethodArgComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int argPosition, int lvIndex, @Nullable String srcArgName,
+			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames,
+			@Nullable String[] dstMethodDescs, @Nullable String[] dstArgNames, String comment, CommentStyle style) throws IOException {
 		if (!visitMethodArg(srcClsName, srcMethodName, srcMethodDesc, argPosition, lvIndex, srcArgName,
 				dstClsNames, dstMethodNames, dstMethodDescs, dstArgNames, null, null, null, null)) {
 			return;
 		}
 
-		next.visitComment(MappedElementKind.METHOD_ARG, comment);
+		next.visitComment(MappedElementKind.METHOD_ARG, comment, style);
 	}
 
 	@Override
 	public void visitMethodArgComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
 			int argPosition, int lvIndex, @Nullable String srcArgName,
 			@Nullable String dstClsName, @Nullable String dstMethodName,
-			@Nullable String dstMethodDesc, @Nullable String dstArgName, String comment) throws IOException {
+			@Nullable String dstMethodDesc, @Nullable String dstArgName, String comment, CommentStyle style) throws IOException {
 		if (!visitMethodArg(srcClsName, srcMethodName, srcMethodDesc, argPosition, lvIndex, srcArgName,
 				null, null, null, null, dstClsName, dstMethodName, dstMethodDesc, dstArgName)) {
 			return;
 		}
 
-		next.visitComment(MappedElementKind.METHOD_ARG, comment);
+		next.visitComment(MappedElementKind.METHOD_ARG, comment, style);
 	}
 
 	@Override
@@ -296,25 +328,36 @@ public final class RegularAsFlatMappingVisitor implements FlatMappingVisitor {
 			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcVarName,
 			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames, @Nullable String[] dstMethodDescs,
 			@Nullable String[] dstVarNames, String comment) throws IOException {
+		visitMethodVarComment(srcClsName, srcMethodName, srcMethodDesc,
+				lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcVarName,
+				dstClsNames, dstMethodNames, dstMethodDescs,
+				dstVarNames, comment, CommentStyle.HTML);
+	}
+
+	@Override
+	public void visitMethodVarComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
+			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcVarName,
+			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames, @Nullable String[] dstMethodDescs,
+			@Nullable String[] dstVarNames, String comment, CommentStyle style) throws IOException {
 		if (!visitMethodVar(srcClsName, srcMethodName, srcMethodDesc, lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcVarName,
 				dstClsNames, dstMethodNames, dstMethodDescs, dstVarNames, null, null, null, null)) {
 			return;
 		}
 
-		next.visitComment(MappedElementKind.METHOD_VAR, comment);
+		next.visitComment(MappedElementKind.METHOD_VAR, comment, style);
 	}
 
 	@Override
 	public void visitMethodVarComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc,
 			int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcVarName,
 			@Nullable String dstClsName, @Nullable String dstMethodName, @Nullable String dstMethodDesc,
-			@Nullable String dstVarName, String comment) throws IOException {
+			@Nullable String dstVarName, String comment, CommentStyle style) throws IOException {
 		if (!visitMethodVar(srcClsName, srcMethodName, srcMethodDesc, lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcVarName,
 				null, null, null, null, dstClsName, dstMethodName, dstMethodDesc, dstVarName)) {
 			return;
 		}
 
-		next.visitComment(MappedElementKind.METHOD_VAR, comment);
+		next.visitComment(MappedElementKind.METHOD_VAR, comment, style);
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/mappingio/adapter/SubsetChecker.java
+++ b/src/main/java/net/fabricmc/mappingio/adapter/SubsetChecker.java
@@ -26,11 +26,10 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import net.fabricmc.mappingio.CommentStyle;
-
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
+import net.fabricmc.mappingio.CommentStyle;
 import net.fabricmc.mappingio.FlatMappingVisitor;
 import net.fabricmc.mappingio.MappingUtil;
 import net.fabricmc.mappingio.format.FeatureSet;

--- a/src/main/java/net/fabricmc/mappingio/adapter/SubsetChecker.java
+++ b/src/main/java/net/fabricmc/mappingio/adapter/SubsetChecker.java
@@ -26,6 +26,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import net.fabricmc.mappingio.CommentStyle;
+
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
@@ -196,11 +198,17 @@ public class SubsetChecker implements FlatMappingVisitor {
 
 	@Override
 	public void visitClassComment(String srcName, @Nullable String[] dstNames, String comment) throws IOException {
+		visitClassComment(srcName, dstNames, comment, CommentStyle.HTML);
+	}
+
+	@Override
+	public void visitClassComment(String srcName, @Nullable String[] dstNames, String comment, CommentStyle style) throws IOException {
 		if (!supFeatures.supportsClasses() || supFeatures.elementComments() == ElementCommentSupport.NONE) return;
 
 		ClassMappingView supCls = requireNonNull(supTree.getClass(srcName), "Incoming class comment's parent class not contained in supTree: " + srcName);
 
 		assertEquals(supCls.getComment(), comment, "Incoming class comment not contained in supTree: " + srcName);
+		assertEquals(supCls.getCommentStyle(), style, "Incoming class comment style differs from supTree: " + srcName);
 	}
 
 	@Override
@@ -301,6 +309,12 @@ public class SubsetChecker implements FlatMappingVisitor {
 	@Override
 	public void visitFieldComment(String srcClsName, String srcName, @Nullable String srcDesc,
 			@Nullable String[] dstClsNames, @Nullable String[] dstNames, @Nullable String[] dstDescs, String comment) throws IOException {
+		visitFieldComment(srcClsName, srcName, srcDesc, dstClsNames, dstNames, dstDescs, comment, CommentStyle.HTML);
+	}
+
+	@Override
+	public void visitFieldComment(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String[] dstClsNames, @Nullable String[] dstNames, @Nullable String[] dstDescs, String comment, CommentStyle style) throws IOException {
 		if (!supFeatures.supportsFields() || supFeatures.elementComments() == ElementCommentSupport.NONE) return;
 
 		String subFldId = srcClsName + "#" + srcName + ":" + srcDesc;
@@ -308,6 +322,7 @@ public class SubsetChecker implements FlatMappingVisitor {
 		FieldMappingView supFld = requireNonNull(supCls.getField(srcName, srcDesc), "Incoming field comment's parent field not contained in supTree: " + subFldId);
 
 		assertEquals(supFld.getComment(), comment, "Incoming comment differs from supTree");
+		assertEquals(supFld.getCommentStyle(), style, "Incoming comment style differs from supTree: " + srcName);
 	}
 
 	@Override
@@ -410,6 +425,12 @@ public class SubsetChecker implements FlatMappingVisitor {
 	@Override
 	public void visitMethodComment(String srcClsName, String srcName, @Nullable String srcDesc,
 			@Nullable String[] dstClsNames, @Nullable String[] dstNames, @Nullable String[] dstDescs, String comment) throws IOException {
+		visitMethodComment(srcClsName, srcName, srcDesc, dstClsNames, dstNames, dstDescs, comment, CommentStyle.HTML);
+	}
+
+	@Override
+	public void visitMethodComment(String srcClsName, String srcName, @Nullable String srcDesc,
+			@Nullable String[] dstClsNames, @Nullable String[] dstNames, @Nullable String[] dstDescs, String comment, CommentStyle style) throws IOException {
 		if (!supFeatures.supportsMethods() || supFeatures.elementComments() == ElementCommentSupport.NONE) return;
 
 		String subMthId = srcClsName + "#" + srcName + srcDesc;
@@ -417,6 +438,7 @@ public class SubsetChecker implements FlatMappingVisitor {
 		MethodMappingView supMth = requireNonNull(supCls.getMethod(srcName, srcDesc), "Incoming method comment's parent method not contained in supTree: " + subMthId);
 
 		assertEquals(supMth.getComment(), comment, "Incoming comment differs from supTree");
+		assertEquals(supMth.getCommentStyle(), style, "Incoming comment style differs from supTree");
 	}
 
 	@Override
@@ -485,6 +507,13 @@ public class SubsetChecker implements FlatMappingVisitor {
 	@Override
 	public void visitMethodArgComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc, int argPosition, int lvIndex, @Nullable String srcArgName,
 			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames, @Nullable String[] dstMethodDescs, @Nullable String[] dstNames, String comment) throws IOException {
+		visitMethodArgComment(srcClsName, srcMethodName, srcMethodDesc, argPosition, lvIndex, srcArgName,
+				dstClsNames, dstMethodNames, dstMethodDescs, dstNames, comment, CommentStyle.HTML);
+	}
+
+	@Override
+	public void visitMethodArgComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc, int argPosition, int lvIndex, @Nullable String srcArgName,
+			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames, @Nullable String[] dstMethodDescs, @Nullable String[] dstNames, String comment, CommentStyle style) throws IOException {
 		if (!supFeatures.supportsArgs() || supFeatures.elementComments() == ElementCommentSupport.NONE) return;
 
 		String subArgId = srcClsName + "#" + srcMethodName + srcMethodDesc + ":" + argPosition + ":" + lvIndex + ":" + srcArgName;
@@ -494,6 +523,7 @@ public class SubsetChecker implements FlatMappingVisitor {
 		MethodArgMappingView supArg = requireNonNull(supMth.getArg(argPosition, lvIndex, srcArgName), "Incoming arg comment's parent arg not contained in supTree: " + subArgId);
 
 		assertEquals(supArg.getComment(), comment, "Incoming comment differs from supTree");
+		assertEquals(supArg.getCommentStyle(), style, "Incoming comment style differs from supTree");
 	}
 
 	@Override
@@ -573,6 +603,13 @@ public class SubsetChecker implements FlatMappingVisitor {
 	@Override
 	public void visitMethodVarComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc, int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcVarName,
 			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames, @Nullable String[] dstMethodDescs, @Nullable String[] dstNames, String comment) throws IOException {
+		visitMethodVarComment(srcClsName, srcMethodName, srcMethodDesc, lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcVarName,
+				dstClsNames, dstMethodNames, dstMethodDescs, dstNames, comment, CommentStyle.HTML);
+	}
+
+	@Override
+	public void visitMethodVarComment(String srcClsName, String srcMethodName, @Nullable String srcMethodDesc, int lvtRowIndex, int lvIndex, int startOpIdx, int endOpIdx, @Nullable String srcVarName,
+			@Nullable String[] dstClsNames, @Nullable String[] dstMethodNames, @Nullable String[] dstMethodDescs, @Nullable String[] dstNames, String comment, CommentStyle style) throws IOException {
 		if (!supFeatures.supportsVars() || supFeatures.elementComments() == ElementCommentSupport.NONE) return;
 
 		String subVarId = srcClsName + "#" + srcMethodName + srcMethodDesc + ":" + lvtRowIndex + ":" + lvIndex + ":" + startOpIdx + ":" + endOpIdx + ":" + srcVarName;
@@ -582,6 +619,7 @@ public class SubsetChecker implements FlatMappingVisitor {
 		MethodVarMappingView supVar = requireNonNull(supMth.getVar(lvtRowIndex, lvIndex, startOpIdx, endOpIdx, srcVarName), "Incoming var comment's parent var not contained in supTree: " + subVarId);
 
 		assertEquals(supVar.getComment(), comment, "Incoming comment differs from supTree");
+		assertEquals(supVar.getCommentStyle(), style, "Incoming comment style differs from supTree");
 	}
 
 	protected void assertTrue(boolean condition, String message) {

--- a/src/main/java/net/fabricmc/mappingio/adapter/VisitOrderVerifier.java
+++ b/src/main/java/net/fabricmc/mappingio/adapter/VisitOrderVerifier.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
+import net.fabricmc.mappingio.CommentStyle;
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingVisitor;
 
@@ -293,6 +294,14 @@ public class VisitOrderVerifier extends ForwardingMappingVisitor {
 		assertLastElementContentVisited();
 
 		super.visitComment(targetKind, comment);
+	}
+
+	@Override
+	public void visitComment(MappedElementKind targetKind, String comment, CommentStyle style) throws IOException {
+		assertElementVisited(targetKind);
+		assertLastElementContentVisited();
+
+		super.visitComment(targetKind, comment, style);
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaFileReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaFileReader.java
@@ -135,7 +135,7 @@ public final class EnigmaFileReader {
 			} else if (reader.nextCol("COMMENT")) { // comment: COMMENT <comment>
 				commentSb.style = CommentStyle.HTML;
 				readComment(reader, commentSb);
-			} else if (reader.nextCol("COMMENT")) { // markdown comment: MDCOMMENT <comment>
+			} else if (reader.nextCol("MDCOMMENT")) { // markdown comment: MDCOMMENT <comment>
 				commentSb.style = CommentStyle.MARKDOWN;
 				readComment(reader, commentSb);
 			} else if ((isMethod = reader.nextCol("METHOD")) || reader.nextCol("FIELD")) { // method: METHOD <name-a> [<name-b>] <desc-a> or field: FIELD <name-a> [<name-b>] <desc-a>

--- a/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaFileReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaFileReader.java
@@ -21,6 +21,7 @@ import java.io.Reader;
 import java.util.Collections;
 import java.util.Set;
 
+import net.fabricmc.mappingio.CommentStyle;
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingFlag;
 import net.fabricmc.mappingio.MappingUtil;
@@ -67,7 +68,7 @@ public final class EnigmaFileReader {
 			}
 
 			if (visitor.visitContent()) {
-				StringBuilder commentSb = new StringBuilder(200);
+				CommentBuilder commentSb = new CommentBuilder();
 
 				do {
 					if (reader.nextCol("CLASS")) { // class: CLASS <name-a> [<name-b>]
@@ -91,7 +92,7 @@ public final class EnigmaFileReader {
 		}
 	}
 
-	private static void readClass(ColumnFileReader reader, int indent, String outerSrcClass, String outerDstClass, StringBuilder commentSb, MappingVisitor visitor) throws IOException {
+	private static void readClass(ColumnFileReader reader, int indent, String outerSrcClass, String outerDstClass, CommentBuilder commentSb, MappingVisitor visitor) throws IOException {
 		String srcInnerName = reader.nextCol();
 		if (srcInnerName == null || srcInnerName.isEmpty()) throw new IOException("missing class-name-a in line "+reader.getLineNumber());
 
@@ -116,7 +117,7 @@ public final class EnigmaFileReader {
 		readClassBody(reader, indent, srcName, dstName, commentSb, visitor);
 	}
 
-	private static void readClassBody(ColumnFileReader reader, int indent, String srcClass, String dstClass, StringBuilder commentSb, MappingVisitor visitor) throws IOException {
+	private static void readClassBody(ColumnFileReader reader, int indent, String srcClass, String dstClass, CommentBuilder commentSb, MappingVisitor visitor) throws IOException {
 		boolean visited = false;
 		int state = 0; // 0=invalid 1=visit -1=skip
 
@@ -132,6 +133,10 @@ public final class EnigmaFileReader {
 				readClass(reader, indent + 1, srcClass, dstClass, commentSb, visitor);
 				state = 0;
 			} else if (reader.nextCol("COMMENT")) { // comment: COMMENT <comment>
+				commentSb.style = CommentStyle.HTML;
+				readComment(reader, commentSb);
+			} else if (reader.nextCol("COMMENT")) { // markdown comment: MDCOMMENT <comment>
+				commentSb.style = CommentStyle.MARKDOWN;
 				readComment(reader, commentSb);
 			} else if ((isMethod = reader.nextCol("METHOD")) || reader.nextCol("FIELD")) { // method: METHOD <name-a> [<name-b>] <desc-a> or field: FIELD <name-a> [<name-b>] <desc-a>
 				state = visitClass(srcClass, dstClass, state, commentSb, visitor);
@@ -172,7 +177,7 @@ public final class EnigmaFileReader {
 	/**
 	 * Re-visit a class if necessary and visit its comment if available.
 	 */
-	private static int visitClass(String srcClass, String dstClass, int state, StringBuilder commentSb, MappingVisitor visitor) throws IOException {
+	private static int visitClass(String srcClass, String dstClass, int state, CommentBuilder commentSb, MappingVisitor visitor) throws IOException {
 		// state: 0=invalid 1=visit -1=skip
 
 		if (state == 0) {
@@ -186,7 +191,7 @@ public final class EnigmaFileReader {
 			state = visitContent ? 1 : -1;
 
 			if (commentSb.length() > 0) {
-				if (state > 0) visitor.visitComment(MappedElementKind.CLASS, commentSb.toString());
+				if (state > 0) visitor.visitComment(MappedElementKind.CLASS, commentSb.toString(), commentSb.style);
 
 				commentSb.setLength(0);
 			}
@@ -195,11 +200,15 @@ public final class EnigmaFileReader {
 		return state;
 	}
 
-	private static void readMethod(ColumnFileReader reader, int indent, StringBuilder commentSb, MappingVisitor visitor) throws IOException {
+	private static void readMethod(ColumnFileReader reader, int indent, CommentBuilder commentSb, MappingVisitor visitor) throws IOException {
 		if (!visitor.visitElementContent(MappedElementKind.METHOD)) return;
 
 		while (reader.nextLine(indent + 2)) {
 			if (reader.nextCol("COMMENT")) { // comment: COMMENT <comment>
+				commentSb.style = CommentStyle.HTML;
+				readComment(reader, commentSb);
+			} else if (reader.nextCol("MDCOMMENT")) { // markdown comment: MDCOMMENT <comment>
+				commentSb.style = CommentStyle.MARKDOWN;
 				readComment(reader, commentSb);
 			} else {
 				submitComment(MappedElementKind.METHOD, commentSb, visitor);
@@ -221,11 +230,15 @@ public final class EnigmaFileReader {
 		submitComment(MappedElementKind.METHOD, commentSb, visitor);
 	}
 
-	private static void readElement(ColumnFileReader reader, MappedElementKind kind, int indent, StringBuilder commentSb, MappingVisitor visitor) throws IOException {
+	private static void readElement(ColumnFileReader reader, MappedElementKind kind, int indent, CommentBuilder commentSb, MappingVisitor visitor) throws IOException {
 		if (!visitor.visitElementContent(kind)) return;
 
 		while (reader.nextLine(indent + kind.level + 1)) {
 			if (reader.nextCol("COMMENT")) { // comment: COMMENT <comment>
+				commentSb.style = CommentStyle.HTML;
+				readComment(reader, commentSb);
+			} else if (reader.nextCol("MDCOMMENT")) { // markdown comment: MDCOMMENT <comment>
+				commentSb.style = CommentStyle.MARKDOWN;
 				readComment(reader, commentSb);
 			}
 		}
@@ -233,7 +246,7 @@ public final class EnigmaFileReader {
 		submitComment(kind, commentSb, visitor);
 	}
 
-	private static void readComment(ColumnFileReader reader, StringBuilder commentSb) throws IOException {
+	private static void readComment(ColumnFileReader reader, CommentBuilder commentSb) throws IOException {
 		if (commentSb.length() > 0) commentSb.append('\n');
 
 		String comment = reader.nextCols(true);
@@ -243,10 +256,36 @@ public final class EnigmaFileReader {
 		}
 	}
 
-	private static void submitComment(MappedElementKind kind, StringBuilder commentSb, MappingVisitor visitor) throws IOException {
+	private static void submitComment(MappedElementKind kind, CommentBuilder commentSb, MappingVisitor visitor) throws IOException {
 		if (commentSb.length() == 0) return;
 
-		visitor.visitComment(kind, commentSb.toString());
+		visitor.visitComment(kind, commentSb.toString(), commentSb.style);
 		commentSb.setLength(0);
+	}
+
+	private static final class CommentBuilder {
+		int length() {
+			return sb.length();
+		}
+
+		void setLength(int length) {
+			sb.setLength(length);
+		}
+
+		void append(String str) {
+			sb.append(str);
+		}
+
+		void append(char c) {
+			sb.append(c);
+		}
+
+		@Override
+		public String toString() {
+			return sb.toString();
+		}
+
+		private final StringBuilder sb = new StringBuilder(200);
+		private CommentStyle style = CommentStyle.HTML;
 	}
 }

--- a/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaWriterBase.java
+++ b/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaWriterBase.java
@@ -22,6 +22,8 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
+import net.fabricmc.mappingio.CommentStyle;
+
 import org.jetbrains.annotations.Nullable;
 
 import net.fabricmc.mappingio.MappedElementKind;
@@ -143,6 +145,11 @@ abstract class EnigmaWriterBase implements MappingWriter {
 
 	@Override
 	public void visitComment(MappedElementKind targetKind, String comment) throws IOException {
+		visitComment(targetKind, comment, CommentStyle.HTML);
+	}
+
+	@Override
+	public void visitComment(MappedElementKind targetKind, String comment, CommentStyle style) throws IOException {
 		int start = 0;
 		int pos;
 
@@ -152,7 +159,7 @@ abstract class EnigmaWriterBase implements MappingWriter {
 			int end = pos >= 0 ? pos : comment.length();
 
 			writeIndent(targetKind.level);
-			writer.write("COMMENT");
+			writer.write(style == CommentStyle.MARKDOWN ? "MDCOMMENT" : "COMMENT");
 
 			if (end > start) {
 				writer.write(' ');

--- a/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaWriterBase.java
+++ b/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaWriterBase.java
@@ -22,10 +22,9 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
-import net.fabricmc.mappingio.CommentStyle;
-
 import org.jetbrains.annotations.Nullable;
 
+import net.fabricmc.mappingio.CommentStyle;
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingFlag;
 import net.fabricmc.mappingio.MappingWriter;

--- a/src/main/java/net/fabricmc/mappingio/format/tiny/Tiny2FileReader.java
+++ b/src/main/java/net/fabricmc/mappingio/format/tiny/Tiny2FileReader.java
@@ -21,6 +21,7 @@ import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.fabricmc.mappingio.CommentStyle;
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingFlag;
 import net.fabricmc.mappingio.MappingVisitor;
@@ -168,7 +169,9 @@ public final class Tiny2FileReader {
 					readMethod(reader, dstNsCount, escapeNames, visitor);
 				}
 			} else if (reader.nextCol("c")) { // comment: c <comment>
-				readComment(reader, MappedElementKind.CLASS, visitor);
+				readComment(reader, MappedElementKind.CLASS, CommentStyle.HTML, visitor);
+			} else if (reader.nextCol("md")) { // markdown comment: md <comment>
+				readComment(reader, MappedElementKind.CLASS, CommentStyle.MARKDOWN, visitor);
 			}
 		}
 	}
@@ -202,7 +205,9 @@ public final class Tiny2FileReader {
 					readElement(reader, MappedElementKind.METHOD_VAR, dstNsCount, escapeNames, visitor);
 				}
 			} else if (reader.nextCol("c")) { // comment: c <comment>
-				readComment(reader, MappedElementKind.METHOD, visitor);
+				readComment(reader, MappedElementKind.METHOD, CommentStyle.HTML, visitor);
+			} else if (reader.nextCol("md")) { // markdown comment: md <comment>
+				readComment(reader, MappedElementKind.METHOD, CommentStyle.MARKDOWN, visitor);
 			}
 		}
 	}
@@ -213,16 +218,18 @@ public final class Tiny2FileReader {
 
 		while (reader.nextLine(kind.level + 1)) {
 			if (reader.nextCol("c")) { // comment: c <comment>
-				readComment(reader, kind, visitor);
+				readComment(reader, kind, CommentStyle.HTML, visitor);
+			} else if (reader.nextCol("md")) { // markdown comment: md <comment>
+				readComment(reader, kind, CommentStyle.MARKDOWN, visitor);
 			}
 		}
 	}
 
-	private static void readComment(ColumnFileReader reader, MappedElementKind subjectKind, MappingVisitor visitor) throws IOException {
+	private static void readComment(ColumnFileReader reader, MappedElementKind subjectKind, CommentStyle style, MappingVisitor visitor) throws IOException {
 		String comment = reader.nextCol(true);
 		if (comment == null) throw new IOException("missing comment in line "+reader.getLineNumber());
 
-		visitor.visitComment(subjectKind, comment);
+		visitor.visitComment(subjectKind, comment, style);
 	}
 
 	private static void readDstNames(ColumnFileReader reader, MappedElementKind subjectKind, int dstNsCount, boolean escapeNames, MappingVisitor visitor) throws IOException {

--- a/src/main/java/net/fabricmc/mappingio/format/tiny/Tiny2FileWriter.java
+++ b/src/main/java/net/fabricmc/mappingio/format/tiny/Tiny2FileWriter.java
@@ -23,10 +23,9 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
-import net.fabricmc.mappingio.CommentStyle;
-
 import org.jetbrains.annotations.Nullable;
 
+import net.fabricmc.mappingio.CommentStyle;
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingFlag;
 import net.fabricmc.mappingio.MappingWriter;

--- a/src/main/java/net/fabricmc/mappingio/format/tiny/Tiny2FileWriter.java
+++ b/src/main/java/net/fabricmc/mappingio/format/tiny/Tiny2FileWriter.java
@@ -23,6 +23,8 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
+import net.fabricmc.mappingio.CommentStyle;
+
 import org.jetbrains.annotations.Nullable;
 
 import net.fabricmc.mappingio.MappedElementKind;
@@ -179,8 +181,13 @@ public final class Tiny2FileWriter implements MappingWriter {
 
 	@Override
 	public void visitComment(MappedElementKind targetKind, String comment) throws IOException {
+		visitComment(targetKind, comment, CommentStyle.HTML);
+	}
+
+	@Override
+	public void visitComment(MappedElementKind targetKind, String comment, CommentStyle style) throws IOException {
 		writeTabs(targetKind.level);
-		write("\tc\t");
+		write(style == CommentStyle.HTML ? "\tc\t" : "\tmd\t");
 		writeEscaped(comment);
 		writeLn();
 	}

--- a/src/main/java/net/fabricmc/mappingio/tree/MappingTree.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MappingTree.java
@@ -21,10 +21,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import net.fabricmc.mappingio.CommentStyle;
-
 import org.jetbrains.annotations.Nullable;
 
+import net.fabricmc.mappingio.CommentStyle;
 import net.fabricmc.mappingio.adapter.MappingDstNsReorder;
 import net.fabricmc.mappingio.adapter.MappingSourceNsSwitch;
 import net.fabricmc.mappingio.adapter.OuterClassNamePropagator;

--- a/src/main/java/net/fabricmc/mappingio/tree/MappingTree.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MappingTree.java
@@ -21,6 +21,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import net.fabricmc.mappingio.CommentStyle;
+
 import org.jetbrains.annotations.Nullable;
 
 import net.fabricmc.mappingio.adapter.MappingDstNsReorder;
@@ -225,7 +227,21 @@ public interface MappingTree extends MappingTreeView {
 		MappingTree getTree();
 
 		void setDstName(String name, int namespace);
+
+		/**
+		 * Sets the HTML-style comment of this mapping.
+		 * @param comment The comment.
+		 */
 		void setComment(String comment);
+
+		/**
+		 * Sets the comment of this mapping.
+		 * @param comment The comment.
+		 * @param style   The comment style.
+		 */
+		default void setComment(String comment, CommentStyle style) {
+			setComment(comment);
+		}
 	}
 
 	interface ClassMapping extends ElementMapping, ClassMappingView {

--- a/src/main/java/net/fabricmc/mappingio/tree/MappingTreeView.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MappingTreeView.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
+import net.fabricmc.mappingio.CommentStyle;
+
 import org.jetbrains.annotations.Nullable;
 
 import net.fabricmc.mappingio.MappingVisitor;
@@ -245,6 +247,10 @@ public interface MappingTreeView {
 
 		@Nullable
 		String getComment();
+
+		default CommentStyle getCommentStyle() {
+			return CommentStyle.HTML;
+		}
 	}
 
 	interface ClassMappingView extends ElementMappingView {

--- a/src/main/java/net/fabricmc/mappingio/tree/MappingTreeView.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MappingTreeView.java
@@ -20,10 +20,9 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
-import net.fabricmc.mappingio.CommentStyle;
-
 import org.jetbrains.annotations.Nullable;
 
+import net.fabricmc.mappingio.CommentStyle;
 import net.fabricmc.mappingio.MappingVisitor;
 
 /**

--- a/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
@@ -33,6 +33,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import net.fabricmc.mappingio.CommentStyle;
+
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
@@ -809,6 +811,11 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 
 	@Override
 	public void visitComment(MappedElementKind targetKind, String comment) {
+		visitComment(targetKind, comment, CommentStyle.HTML);
+	}
+
+	@Override
+	public void visitComment(MappedElementKind targetKind, String comment, CommentStyle style) {
 		Entry<?> entry;
 
 		switch (targetKind) {
@@ -823,7 +830,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		if (entry == null) throw new UnsupportedOperationException("Tried to visit comment before owning target");
-		entry.setCommentInternal(comment);
+		entry.setCommentInternal(comment, style);
 	}
 
 	private static boolean isValidDescriptor(String descriptor, boolean possiblyMethod) {
@@ -862,7 +869,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 				}
 			}
 
-			setCommentInternal(src.getComment());
+			setCommentInternal(src.getComment(), src.getCommentStyle());
 		}
 
 		public abstract MappedElementKind getKind();
@@ -940,12 +947,18 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 
 		@Override
 		public final void setComment(String comment) {
-			tree.assertNotInVisitPass();
-			setCommentInternal(comment);
+			setComment(comment, CommentStyle.HTML);
 		}
 
-		void setCommentInternal(String comment) {
+		@Override
+		public final void setComment(String comment, CommentStyle style) {
+			tree.assertNotInVisitPass();
+			setCommentInternal(comment, style);
+		}
+
+		void setCommentInternal(String comment, CommentStyle style) {
 			this.comment = comment;
+			this.commentStyle = style;
 		}
 
 		protected final boolean acceptElement(MappingVisitor visitor, @Nullable String[] dstDescs) throws IOException {
@@ -991,6 +1004,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		private String srcName;
 		protected String[] dstNames;
 		protected String comment;
+		protected CommentStyle commentStyle = CommentStyle.HTML;
 	}
 
 	static final class ClassEntry extends Entry<ClassEntry> implements ClassMapping {

--- a/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
@@ -970,6 +970,11 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 			this.commentStyle = style;
 		}
 
+		@Override
+		public final CommentStyle getCommentStyle() {
+			return commentStyle;
+		}
+
 		protected final boolean acceptElement(MappingVisitor visitor, @Nullable String[] dstDescs) throws IOException {
 			MappedElementKind kind = getKind();
 

--- a/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
@@ -33,11 +33,10 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import net.fabricmc.mappingio.CommentStyle;
-
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
+import net.fabricmc.mappingio.CommentStyle;
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingFlag;
 import net.fabricmc.mappingio.MappingVisitor;

--- a/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
@@ -996,7 +996,7 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 				return false;
 			}
 
-			if (comment != null) visitor.visitComment(kind, comment);
+			if (comment != null) visitor.visitComment(kind, comment, commentStyle);
 
 			return true;
 		}

--- a/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
+++ b/src/main/java/net/fabricmc/mappingio/tree/MemoryMappingTree.java
@@ -957,6 +957,15 @@ public final class MemoryMappingTree implements VisitableMappingTree {
 		}
 
 		void setCommentInternal(String comment, CommentStyle style) {
+			if (style == null) {
+				if (comment == null) {
+					// Fall back to default
+					style = CommentStyle.HTML;
+				} else {
+					throw new NullPointerException("Comment style cannot be null for nonnull comment");
+				}
+			}
+
 			this.comment = comment;
 			this.commentStyle = style;
 		}

--- a/src/test/java/net/fabricmc/mappingio/test/NameGen.java
+++ b/src/test/java/net/fabricmc/mappingio/test/NameGen.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import net.fabricmc.mappingio.CommentStyle;
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingVisitor;
 
@@ -102,7 +103,7 @@ class NameGen {
 	}
 
 	void visitComment(MappingVisitor target) throws IOException {
-		target.visitComment(lastKind, comment);
+		target.visitComment(lastKind, comment, CommentStyle.HTML);
 	}
 
 	private String src(MappedElementKind kind) {

--- a/src/test/java/net/fabricmc/mappingio/test/NameGen.java
+++ b/src/test/java/net/fabricmc/mappingio/test/NameGen.java
@@ -106,6 +106,10 @@ class NameGen {
 		target.visitComment(lastKind, comment, CommentStyle.HTML);
 	}
 
+	void visitMarkdownComment(MappingVisitor target) throws IOException {
+		target.visitComment(lastKind, comment, CommentStyle.MARKDOWN);
+	}
+
 	private String src(MappedElementKind kind) {
 		nsNum = 0;
 		lastKind = kind;

--- a/src/test/java/net/fabricmc/mappingio/test/TestMappings.java
+++ b/src/test/java/net/fabricmc/mappingio/test/TestMappings.java
@@ -28,10 +28,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import net.fabricmc.mappingio.CommentStyle;
-
 import org.jetbrains.annotations.Nullable;
 
+import net.fabricmc.mappingio.CommentStyle;
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingReader;
 import net.fabricmc.mappingio.MappingUtil;

--- a/src/test/java/net/fabricmc/mappingio/test/TestMappings.java
+++ b/src/test/java/net/fabricmc/mappingio/test/TestMappings.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import net.fabricmc.mappingio.CommentStyle;
+
 import org.jetbrains.annotations.Nullable;
 
 import net.fabricmc.mappingio.MappedElementKind;
@@ -173,6 +175,15 @@ public class TestMappings {
 				}
 
 				super.visitComment(targetKind, comment);
+			}
+
+			@Override
+			public void visitComment(MappedElementKind targetKind, String comment, CommentStyle style) throws IOException {
+				if (repeatComments) {
+					super.visitComment(targetKind, comment + ".", style);
+				}
+
+				super.visitComment(targetKind, comment, style);
 			}
 		});
 

--- a/src/test/java/net/fabricmc/mappingio/test/TestMappings.java
+++ b/src/test/java/net/fabricmc/mappingio/test/TestMappings.java
@@ -68,7 +68,9 @@ public class TestMappings {
 			NameGen nameGen = new NameGen();
 
 			if (nameGen.visitClass(delegate, dstNs)) {
-				nameGen.visitField(delegate, dstNs);
+				if (nameGen.visitField(delegate, dstNs)) {
+					nameGen.visitMarkdownComment(delegate);
+				}
 
 				if (nameGen.visitMethod(delegate, dstNs)) {
 					nameGen.visitMethodArg(delegate, dstNs);

--- a/src/test/java/net/fabricmc/mappingio/test/tests/tree/MergeTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/tree/MergeTest.java
@@ -26,6 +26,8 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 
+import net.fabricmc.mappingio.CommentStyle;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -73,7 +75,7 @@ public class MergeTest {
 		delegate.visitElementContent(MappedElementKind.CLASS);
 		delegate.visitField(fld1Ns1Name, null);
 		delegate.visitElementContent(MappedElementKind.FIELD);
-		delegate.visitComment(MappedElementKind.FIELD, fld1Comment);
+		delegate.visitComment(MappedElementKind.FIELD, fld1Comment, CommentStyle.HTML);
 		delegate.visitEnd();
 
 		ClassMapping cls = tree.getClass(cls1Ns1Name);
@@ -91,7 +93,7 @@ public class MergeTest {
 		delegate.visitElementContent(MappedElementKind.CLASS);
 		delegate.visitField(fld1Ns1Name, fld1Ns1Desc);
 		delegate.visitElementContent(MappedElementKind.FIELD);
-		delegate.visitComment(MappedElementKind.FIELD, fld1Comment);
+		delegate.visitComment(MappedElementKind.FIELD, fld1Comment, CommentStyle.HTML);
 		delegate.visitEnd();
 
 		ClassMapping cls = tree.getClass(cls1Ns1Name);

--- a/src/test/java/net/fabricmc/mappingio/test/tests/tree/MergeTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/tree/MergeTest.java
@@ -26,11 +26,10 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 
-import net.fabricmc.mappingio.CommentStyle;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import net.fabricmc.mappingio.CommentStyle;
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingReader;
 import net.fabricmc.mappingio.MappingVisitor;

--- a/src/test/java/net/fabricmc/mappingio/test/tests/visiting/VisitEndTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/visiting/VisitEndTest.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
+import net.fabricmc.mappingio.CommentStyle;
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingFlag;
 import net.fabricmc.mappingio.MappingVisitor;
@@ -188,6 +189,12 @@ public class VisitEndTest {
 		public void visitComment(MappedElementKind targetKind, String comment) throws IOException {
 			check();
 			tree.visitComment(targetKind, comment);
+		}
+
+		@Override
+		public void visitComment(MappedElementKind targetKind, String comment, CommentStyle style) throws IOException {
+			check();
+			tree.visitComment(targetKind, comment, style);
 		}
 
 		@Override

--- a/src/test/java/net/fabricmc/mappingio/test/tests/writing/WriteTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/writing/WriteTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import net.fabricmc.mappingio.CommentStyle;
+
 import net.neoforged.srgutils.IMappingFile;
 import net.neoforged.srgutils.INamedMappingFile;
 import org.junit.jupiter.api.Test;
@@ -105,16 +107,23 @@ public class WriteTest {
 		// TODO: Remove once https://github.com/neoforged/SRGUtils/issues/7 is fixed
 		if (format == MappingFormat.PROGUARD_FILE) return;
 
-		// SrgUtils can't handle empty dst names
+		// SrgUtils can't handle empty dst names or markdown comments
 		VisitableMappingTree dstNsCompTree = new MemoryMappingTree();
 		tree.accept(
 				// TODO: Remove once https://github.com/neoforged/SRGUtils/issues/9 is fixed
 				new MappingNsCompleter(
-						// TODO: Remove once https://github.com/neoforged/SRGUtils/issues/8 is fixed
 						new ForwardingMappingVisitor(dstNsCompTree) {
+							// TODO: Remove once https://github.com/neoforged/SRGUtils/issues/8 is fixed
 							@Override
 							public boolean visitElementContent(MappedElementKind targetKind) throws IOException {
 								return !(format == MappingFormat.TINY_2_FILE && targetKind == MappedElementKind.METHOD_VAR);
+							}
+
+							@Override
+							public void visitComment(MappedElementKind targetKind, String comment, CommentStyle style) throws IOException {
+								if (style == CommentStyle.HTML) {
+									super.visitComment(targetKind, comment);
+								}
 							}
 						}));
 

--- a/src/test/java/net/fabricmc/mappingio/test/tests/writing/WriteTest.java
+++ b/src/test/java/net/fabricmc/mappingio/test/tests/writing/WriteTest.java
@@ -21,13 +21,12 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import net.fabricmc.mappingio.CommentStyle;
-
 import net.neoforged.srgutils.IMappingFile;
 import net.neoforged.srgutils.INamedMappingFile;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import net.fabricmc.mappingio.CommentStyle;
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingReader;
 import net.fabricmc.mappingio.MappingVisitor;

--- a/src/test/resources/reading/repeated-elements/enigma-dir/class1Ns0Rename.mapping
+++ b/src/test/resources/reading/repeated-elements/enigma-dir/class1Ns0Rename.mapping
@@ -1,6 +1,7 @@
 CLASS class_1 class1Ns0Rename
 	FIELD field_1 field1Ns0Rename0 I
 	FIELD field_1 field1Ns0Rename I
+		MDCOMMENT This is a comment
 	METHOD method_1 method1Ns0Rename0 ()I
 	METHOD method_1 method1Ns0Rename ()I
 		ARG 1 param1Ns0Rename0

--- a/src/test/resources/reading/repeated-elements/enigma.mappings
+++ b/src/test/resources/reading/repeated-elements/enigma.mappings
@@ -1,18 +1,13 @@
-CLASS class_1 class1Ns0Rename0
 CLASS class_1 class1Ns0Rename
 	FIELD field_1 field1Ns0Rename0 I
 	FIELD field_1 field1Ns0Rename I
+		MDCOMMENT This is a comment
 	METHOD method_1 method1Ns0Rename0 ()I
 	METHOD method_1 method1Ns0Rename ()I
 		ARG 1 param1Ns0Rename0
 		ARG 1 param1Ns0Rename
-	CLASS class_2 class2Ns0Rename0
-	CLASS class_2 class2Ns0Rename1
-		COMMENT This is a comment.
-	CLASS class_2 class2Ns0Rename2
 	CLASS class_2 class2Ns0Rename
 		COMMENT This is a comment
 		FIELD field_2 field2Ns0Rename0 Lcls;
 		FIELD field_2 field2Ns0Rename Lcls;
-CLASS class_3 package_3/class3Ns0Rename0
 CLASS class_3 package_3/class3Ns0Rename

--- a/src/test/resources/reading/repeated-elements/srg.srg
+++ b/src/test/resources/reading/repeated-elements/srg.srg
@@ -1,5 +1,5 @@
 CL: class_1 class1Ns0Rename0
-CL: class_1 class1Ns0Rename1
+CL: class_1 class1Ns0Rename
 FD: class_1/field_1 class1Ns0Rename/field1Ns0Rename0
 FD: class_1/field_1 class1Ns0Rename/field1Ns0Rename
 MD: class_1/method_1 ()I class1Ns0Rename/method1Ns0Rename0 ()I

--- a/src/test/resources/reading/repeated-elements/tinyV2.tiny
+++ b/src/test/resources/reading/repeated-elements/tinyV2.tiny
@@ -6,6 +6,8 @@ c	class_1	class1Ns0Rename0	class1Ns1Rename0
 c	class_1	class1Ns0Rename	class1Ns1Rename
 	f	I	field_1	field1Ns0Rename0	field1Ns1Rename0
 	f	I	field_1	field1Ns0Rename	field1Ns1Rename
+		md	This is a comment.
+		md	This is a comment
 	m	()I	method_1	method1Ns0Rename0	method1Ns1Rename0
 	m	()I	method_1	method1Ns0Rename	method1Ns1Rename
 		p	1	param_1	param1Ns0Rename0	param1Ns1Rename0

--- a/src/test/resources/reading/valid/enigma-dir/class1Ns0Rename.mapping
+++ b/src/test/resources/reading/valid/enigma-dir/class1Ns0Rename.mapping
@@ -1,5 +1,6 @@
 CLASS class_1 class1Ns0Rename
 	FIELD field_1 field1Ns0Rename I
+		MDCOMMENT This is a comment
 	METHOD method_1 method1Ns0Rename ()I
 		ARG 1 param1Ns0Rename
 	CLASS class_2 class2Ns0Rename

--- a/src/test/resources/reading/valid/enigma.mappings
+++ b/src/test/resources/reading/valid/enigma.mappings
@@ -1,5 +1,6 @@
 CLASS class_1 class1Ns0Rename
 	FIELD field_1 field1Ns0Rename I
+		MDCOMMENT This is a comment
 	METHOD method_1 method1Ns0Rename ()I
 		ARG 1 param1Ns0Rename
 	CLASS class_2 class2Ns0Rename

--- a/src/test/resources/reading/valid/tinyV2.tiny
+++ b/src/test/resources/reading/valid/tinyV2.tiny
@@ -4,6 +4,7 @@ tiny	2	0	source	target	target2
 	property-with-null-value
 c	class_1	class1Ns0Rename	class1Ns1Rename
 	f	I	field_1	field1Ns0Rename	field1Ns1Rename
+		md	This is a comment
 	m	()I	method_1	method1Ns0Rename	method1Ns1Rename
 		p	1	param_1	param1Ns0Rename	param1Ns1Rename
 		v	2	2	2	var_1	var1Ns0Rename	var1Ns1Rename


### PR DESCRIPTION
Adds support for MD comments using a new `CommentStyle` enum. All the old methods dealing with comments are assumed to use HTML, and new overloads of all methods have been added to support either `CommentStyle`.

The Enigma and Tiny v2 formats have a change to accommodate the Markdown javadoc. The Enigma marker for MD comments is `MDCOMMENT` instead of `COMMENT`, and the Tiny v2 marker is `md` instead of `c`.
```
# Enigma
CLASS Foo Bar
    MDCOMMENT Hello world

# Tiny
c Foo Bar
    md Hello world
```

When regenerating the test files, some other changes appeared that are unrelated to this PR. Not sure if they're something to fix later.

---

TODO:
- [ ] Expand test coverage to cover all javadoc targets (class, field, method, arg, var)